### PR TITLE
Bugfixes and Improvements

### DIFF
--- a/src/Profitocracy.Core/CoreRegistry.cs
+++ b/src/Profitocracy.Core/CoreRegistry.cs
@@ -11,6 +11,7 @@ public static class CoreRegistry
         return services
             .AddTransient<IProfileService, ProfileService>()
             .AddTransient<ICalculationService, CalculationService>()
-            .AddTransient<ICategoryService, CategoryService>();
+            .AddTransient<ICategoryService, CategoryService>()
+            .AddTransient<ITransactionService, TransactionService>();
     } 
 }

--- a/src/Profitocracy.Core/Domain/Abstractions/Services/IProfileService.cs
+++ b/src/Profitocracy.Core/Domain/Abstractions/Services/IProfileService.cs
@@ -11,4 +11,11 @@ public interface IProfileService
     /// <param name="profileId">The ID of the profile to be set as the current profile.</param>
     /// <returns>Returns the updated profile that is now marked as the current profile.</returns>
     Task<Profile> SetCurrentProfile(Guid profileId);
+
+    /// <summary>
+    /// Deletes the profile with the specified profile ID.
+    /// </summary>
+    /// <param name="profileId">The ID of the profile to be deleted.</param>
+    /// <returns>Returns the GUID of the deleted profile.</returns>
+    Task<Guid> DeleteProfile(Guid profileId);
 }

--- a/src/Profitocracy.Core/Domain/Abstractions/Services/ITransactionService.cs
+++ b/src/Profitocracy.Core/Domain/Abstractions/Services/ITransactionService.cs
@@ -1,0 +1,15 @@
+namespace Profitocracy.Core.Domain.Abstractions.Services;
+
+/// <summary>
+/// Represents a service to manage and
+/// validate transactions within specific contexts
+/// </summary>
+public interface ITransactionService
+{
+    /// <summary>
+    /// Checks if the specified transaction is within the profile's current period.
+    /// </summary>
+    /// <param name="transactionId">The unique identifier of the transaction to check.</param>
+    /// <returns>True if the transaction in the profile's current period, otherwise, false</returns>
+    Task<bool> CheckTransactionInCurrentPeriod(Guid transactionId);
+}

--- a/src/Profitocracy.Core/Domain/Model/Profiles/Profile.cs
+++ b/src/Profitocracy.Core/Domain/Model/Profiles/Profile.cs
@@ -14,6 +14,11 @@ namespace Profitocracy.Core.Domain.Model.Profiles;
 /// </summary>
 public class Profile : AggregateRoot<Guid>
 {
+	
+	private const decimal MainRatio = 0.5m;
+	private const decimal SecondaryRatio = 0.3m;
+	private const decimal SavedRatio = 0.2m;
+	
 	internal Profile(
 		Guid id,
 		string name,
@@ -269,12 +274,13 @@ public class Profile : AggregateRoot<Guid>
 		daysInPeriodFromTomorrow = daysInPeriodFromTomorrow == 0 ? 1 : daysInPeriodFromTomorrow;
 
 		Expenses.TotalBalance.PlannedAmount += StartDate.InitialBalance;
-		Expenses.TodayBalance.PlannedAmount = _todayInitialBalance / daysInActualPeriod;
-		Expenses.TomorrowBalance = Balance / daysInPeriodFromTomorrow;
 		
-		Expenses.Main.PlannedAmount = Expenses.TotalBalance.PlannedAmount * 0.5m;
-		Expenses.Secondary.PlannedAmount = Expenses.TotalBalance.PlannedAmount * 0.3m;
-		Expenses.Saved.PlannedAmount = Expenses.TotalBalance.PlannedAmount * 0.2m;
+		Expenses.TodayBalance.PlannedAmount = _todayInitialBalance < 0 ? 0 : _todayInitialBalance / daysInActualPeriod;
+		Expenses.TomorrowBalance = Balance < 0 ? 0 : Balance / daysInPeriodFromTomorrow;
+		
+		Expenses.Main.PlannedAmount = Expenses.TotalBalance.PlannedAmount * MainRatio;
+		Expenses.Secondary.PlannedAmount = Expenses.TotalBalance.PlannedAmount * SecondaryRatio;
+		Expenses.Saved.PlannedAmount = Expenses.TotalBalance.PlannedAmount * SavedRatio;
 	}
 	
 	private void HandleIncomeTransaction(Transaction transaction)

--- a/src/Profitocracy.Core/Domain/Services/ProfileService.cs
+++ b/src/Profitocracy.Core/Domain/Services/ProfileService.cs
@@ -1,5 +1,6 @@
 using Profitocracy.Core.Domain.Abstractions.Services;
 using Profitocracy.Core.Domain.Model.Profiles;
+using Profitocracy.Core.Exceptions;
 using Profitocracy.Core.Persistence;
 
 namespace Profitocracy.Core.Domain.Services;
@@ -7,10 +8,17 @@ namespace Profitocracy.Core.Domain.Services;
 internal class ProfileService : IProfileService
 {
     private readonly IProfileRepository _profileRepository;
+    private readonly ITransactionRepository _transactionRepository;
+    private readonly ICategoryRepository _categoryRepository;
 
-    public ProfileService(IProfileRepository profileRepository)
+    public ProfileService(
+        IProfileRepository profileRepository, 
+        ITransactionRepository transactionRepository, 
+        ICategoryRepository categoryRepository)
     {
         _profileRepository = profileRepository;
+        _transactionRepository = transactionRepository;
+        _categoryRepository = categoryRepository;
     }
 
     public async Task<Profile> SetCurrentProfile(Guid profileId)
@@ -38,5 +46,43 @@ internal class ProfileService : IProfileService
         }
         
         return currentProfile;
+    }
+
+    public async Task<Guid> DeleteProfile(Guid profileId)
+    {
+        var profiles = await _profileRepository.GetAllProfiles();
+
+        if (profiles.Count == 1)
+        {
+            throw new LastProfileDeletionException(profiles[0].Name);
+        }
+
+        var profileToDelete = await _profileRepository.GetProfileById(profileId);
+
+        if (profileToDelete is null)
+        {
+            return profileId;
+        }
+        
+        var updateCurrent = profileToDelete.IsCurrent;
+            
+        var tasks = new[]
+        {
+            _transactionRepository.DeleteByProfileId(profileId),
+            _categoryRepository.DeleteByProfileId(profileId),
+            _profileRepository.Delete(profileId)
+        };
+        
+        await Task.WhenAll(tasks);
+
+        if (!updateCurrent)
+        {
+            return profileId;
+        }
+        
+        var nextCurrent = profiles.First(p => p.Id != profileId && !p.IsCurrent);
+        await SetCurrentProfile(nextCurrent.Id);
+
+        return profileId;
     }
 }

--- a/src/Profitocracy.Core/Domain/Services/TransactionService.cs
+++ b/src/Profitocracy.Core/Domain/Services/TransactionService.cs
@@ -1,0 +1,38 @@
+using Profitocracy.Core.Domain.Abstractions.Services;
+using Profitocracy.Core.Persistence;
+
+namespace Profitocracy.Core.Domain.Services;
+
+internal class TransactionService : ITransactionService
+{
+    private readonly ITransactionRepository _transactionRepository;
+    private readonly IProfileRepository _profileRepository;
+
+    public TransactionService(
+        ITransactionRepository transactionRepository, 
+        IProfileRepository profileRepository)
+    {
+        _transactionRepository = transactionRepository;
+        _profileRepository = profileRepository;
+    }
+
+    public async Task<bool> CheckTransactionInCurrentPeriod(Guid transactionId)
+    {
+        var transaction = await _transactionRepository.GetById(transactionId);
+
+        if (transaction is null)
+        {
+            return false;
+        }
+        
+        var profile = await _profileRepository.GetCurrentProfile();
+
+        if (profile is null)
+        {
+            return false;
+        }
+        
+        return profile.BillingPeriod.DateFrom <= transaction.Timestamp && 
+               transaction.Timestamp <= profile.BillingPeriod.DateTo;
+    }
+}

--- a/src/Profitocracy.Core/Exceptions/LastProfileDeletionException.cs
+++ b/src/Profitocracy.Core/Exceptions/LastProfileDeletionException.cs
@@ -1,0 +1,11 @@
+namespace Profitocracy.Core.Exceptions;
+
+public class LastProfileDeletionException : Exception
+{
+    public string ProfileName { get; }
+    
+    public LastProfileDeletionException(string profileName)
+    {
+        ProfileName = profileName;
+    }
+}

--- a/src/Profitocracy.Core/Persistence/ICategoryRepository.cs
+++ b/src/Profitocracy.Core/Persistence/ICategoryRepository.cs
@@ -42,4 +42,11 @@ public interface ICategoryRepository
 	/// <param name="categoryId">Category ID to delete</param>
 	/// <returns>ID of deleted category</returns>
 	Task<Guid> Delete(Guid categoryId);
+
+	/// <summary>
+	/// Deletes all categories associated with the specified profile ID.
+	/// </summary>
+	/// <param name="profileId">The ID of the profile whose categories should be deleted.</param>
+	/// <returns>A task representing the asynchronous operation.</returns>
+	Task DeleteByProfileId(Guid profileId);
 }

--- a/src/Profitocracy.Core/Persistence/IProfileRepository.cs
+++ b/src/Profitocracy.Core/Persistence/IProfileRepository.cs
@@ -46,4 +46,11 @@ public interface IProfileRepository
 	/// <param name="profile">Profile to update</param>
 	/// <returns>Updated profile</returns>
 	Task<Profile> Update(Profile profile);
+
+	/// <summary>
+	/// Deletes a profile by its unique identifier.
+	/// </summary>
+	/// <param name="id">The unique identifier of the profile to delete.</param>
+	/// <returns>The identifier of the deleted profile.</returns>
+	Task<Guid> Delete(Guid id);
 }

--- a/src/Profitocracy.Core/Persistence/ITransactionRepository.cs
+++ b/src/Profitocracy.Core/Persistence/ITransactionRepository.cs
@@ -74,4 +74,11 @@ public interface ITransactionRepository
 	/// <param name="transactionId">ID of transaction to delete</param>
 	/// <returns>Deleted transaction ID</returns>
 	Task<Guid> Delete(Guid transactionId);
+
+	/// <summary>
+	/// Deletes all transactions associated with a specific profile identifier.
+	/// </summary>
+	/// <param name="profileId">The identifier of the profile for which to delete transactions.</param>
+	/// <returns>A task that represents the asynchronous operation.</returns>
+	Task DeleteByProfileId(Guid profileId);
 }

--- a/src/Profitocracy.Infrastructure/Persistence/Sqlite/Configuration/DbConnection.cs
+++ b/src/Profitocracy.Infrastructure/Persistence/Sqlite/Configuration/DbConnection.cs
@@ -29,7 +29,7 @@ internal class DbConnection
 		}
 	}
 
-	public async Task Init()
+	public async ValueTask Init()
 	{
 		if (_database is not null)
 		{

--- a/src/Profitocracy.Infrastructure/Persistence/Sqlite/Repositories/CategoryRepository.cs
+++ b/src/Profitocracy.Infrastructure/Persistence/Sqlite/Repositories/CategoryRepository.cs
@@ -89,4 +89,13 @@ internal class CategoryRepository : ICategoryRepository
 		
 		return categoryId;
 	}
+
+	public async Task DeleteByProfileId(Guid profileId)
+	{
+		await _dbConnection.Init();
+		
+		await _dbConnection.Database
+			.Table<CategoryModel>()
+			.DeleteAsync(c => c.ProfileId == profileId);
+	}
 }

--- a/src/Profitocracy.Infrastructure/Persistence/Sqlite/Repositories/ProfileRepository.cs
+++ b/src/Profitocracy.Infrastructure/Persistence/Sqlite/Repositories/ProfileRepository.cs
@@ -49,6 +49,17 @@ internal class ProfileRepository : IProfileRepository
 		return _mapper.MapToDomain(updatedProfile);
 	}
 
+	public async Task<Guid> Delete(Guid id)
+	{
+		await _dbConnection.Init();
+		
+		await _dbConnection.Database
+			.Table<ProfileModel>()
+			.DeleteAsync(p => p.Id == id);
+		
+		return id;
+	}
+
 	public async Task<Guid?> GetCurrentProfileId()
 	{
 		await _dbConnection.Init();

--- a/src/Profitocracy.Infrastructure/Persistence/Sqlite/Repositories/TransactionRepository.cs
+++ b/src/Profitocracy.Infrastructure/Persistence/Sqlite/Repositories/TransactionRepository.cs
@@ -208,4 +208,13 @@ internal class TransactionRepository : ITransactionRepository
 
 		return transactionId;
 	}
+
+	public async Task DeleteByProfileId(Guid profileId)
+	{
+		await _dbConnection.Init();
+		
+		await _dbConnection.Database
+			.Table<TransactionModel>()
+			.DeleteAsync(t => t.ProfileId == profileId);
+	}
 }

--- a/src/Profitocracy.Mobile/MauiProgram.cs
+++ b/src/Profitocracy.Mobile/MauiProgram.cs
@@ -86,8 +86,8 @@ public static class MauiProgram
 	private static MauiAppBuilder RegisterViews(this MauiAppBuilder mauiAppBuilder)
 	{
 		_ = mauiAppBuilder.Services
-			.AddSingleton<HomePage>()
-			.AddSingleton<TransactionsPage>()
+			.AddTransient<HomePage>()
+			.AddTransient<TransactionsPage>()
 			.AddTransient<FilteredTransactionsPage>()
 			.AddTransient<EditTransactionPage>()
 			.AddTransient<ExpenseCategoriesSettingsPage>()

--- a/src/Profitocracy.Mobile/Models/Transactions/TransactionModel.cs
+++ b/src/Profitocracy.Mobile/Models/Transactions/TransactionModel.cs
@@ -34,6 +34,23 @@ public class TransactionModel
     {
         get
         {
+            var amount = Amount.ToString(CultureInfo.CurrentCulture);
+            
+            return Type == 0 
+                ? $"+{amount.ToString(CultureInfo.CurrentCulture)}" 
+                : $"-{amount.ToString(CultureInfo.CurrentCulture)}";
+        }
+    }
+
+    public string AdditionalDisplayAmount
+    {
+        get
+        {
+            if (!IsMultiCurrency)
+            {
+                return string.Empty;
+            }
+            
             var amount = IsMultiCurrency 
                 ? DestinationCurrency + ((decimal)DestinationAmount!).ToString(CultureInfo.CurrentCulture) 
                 : Amount.ToString(CultureInfo.CurrentCulture);
@@ -49,23 +66,6 @@ public class TransactionModel
             return SpendingType == 2 
                 ? $"+{amount}" 
                 : $"-{amount}";
-        }
-    }
-
-    public string AdditionalDisplayAmount
-    {
-        get
-        {
-            if (!IsMultiCurrency)
-            {
-                return string.Empty;
-            }
-
-            var amount = Amount.ToString(CultureInfo.CurrentCulture);
-            
-            return Type == 0 
-                ? $"+{amount.ToString(CultureInfo.CurrentCulture)}" 
-                : $"-{amount.ToString(CultureInfo.CurrentCulture)}";
         }
     }
 

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.Designer.cs
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.Designer.cs
@@ -1016,5 +1016,119 @@ namespace Profitocracy.Mobile.Resources.Strings {
                 return ResourceManager.GetString("Settings_GitHub", resourceCulture);
             }
         }
+        
+        internal static string CategoriesSettings_DeleteAlert_Title {
+            get {
+                return ResourceManager.GetString("CategoriesSettings_DeleteAlert_Title", resourceCulture);
+            }
+        }
+        
+        internal static string CategoriesSettings_DeleteAlert_Ok {
+            get {
+                return ResourceManager.GetString("CategoriesSettings_DeleteAlert_Ok", resourceCulture);
+            }
+        }
+        
+        internal static string CategoriesSettings_DeleteAlert_Cancel {
+            get {
+                return ResourceManager.GetString("CategoriesSettings_DeleteAlert_Cancel", resourceCulture);
+            }
+        }
+        
+        internal static string CategoriesSettings_DeleteAlert_Description {
+            get {
+                return ResourceManager.GetString("CategoriesSettings_DeleteAlert_Description", resourceCulture);
+            }
+        }
+        
+        internal static string Transactions_DeleteAlert_Cancel {
+            get {
+                return ResourceManager.GetString("Transactions_DeleteAlert_Cancel", resourceCulture);
+            }
+        }
+        
+        internal static string Transactions_DeleteAlert_Ok {
+            get {
+                return ResourceManager.GetString("Transactions_DeleteAlert_Ok", resourceCulture);
+            }
+        }
+        
+        internal static string Transactions_DeleteAlert_Title {
+            get {
+                return ResourceManager.GetString("Transactions_DeleteAlert_Title", resourceCulture);
+            }
+        }
+        
+        internal static string Transactions_DeleteAlert_Description {
+            get {
+                return ResourceManager.GetString("Transactions_DeleteAlert_Description", resourceCulture);
+            }
+        }
+        
+        internal static string Transactions_EditNotInPeriodAlert_Cancel {
+            get {
+                return ResourceManager.GetString("Transactions_EditNotInPeriodAlert_Cancel", resourceCulture);
+            }
+        }
+        
+        internal static string Transactions_EditNotInPeriodAlert_Ok {
+            get {
+                return ResourceManager.GetString("Transactions_EditNotInPeriodAlert_Ok", resourceCulture);
+            }
+        }
+        
+        internal static string Transactions_EditNotInPeriodAlert_Description {
+            get {
+                return ResourceManager.GetString("Transactions_EditNotInPeriodAlert_Description", resourceCulture);
+            }
+        }
+        
+        internal static string Transactions_EditNotInPeriodAlert_Title {
+            get {
+                return ResourceManager.GetString("Transactions_EditNotInPeriodAlert_Title", resourceCulture);
+            }
+        }
+        
+        internal static string ProfileSettings_DeleteAlert_Cancel {
+            get {
+                return ResourceManager.GetString("ProfileSettings_DeleteAlert_Cancel", resourceCulture);
+            }
+        }
+        
+        internal static string ProfileSettings_DeleteAlert_Ok {
+            get {
+                return ResourceManager.GetString("ProfileSettings_DeleteAlert_Ok", resourceCulture);
+            }
+        }
+        
+        internal static string ProfileSettings_DeleteAlert_Description {
+            get {
+                return ResourceManager.GetString("ProfileSettings_DeleteAlert_Description", resourceCulture);
+            }
+        }
+        
+        internal static string ProfileSettings_DeleteAlert_Title {
+            get {
+                return ResourceManager.GetString("ProfileSettings_DeleteAlert_Title", resourceCulture);
+            }
+        }
+        
+        internal static string ProfileSettings_LastProfileErrorAlert_Title {
+            get {
+                return ResourceManager.GetString("ProfileSettings_LastProfileErrorAlert_Title", resourceCulture);
+            }
+        }
+        
+        internal static string ProfileSettings_LastProfileErrorAlert_Description {
+            get {
+                return ResourceManager.GetString("ProfileSettings_LastProfileErrorAlert_Description", resourceCulture);
+            }
+        }
+        
+        internal static string ProfileSettings_LastProfileErrorAlert_Ok {
+            get {
+                return ResourceManager.GetString("ProfileSettings_LastProfileErrorAlert_Ok", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.resx
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.resx
@@ -142,7 +142,7 @@
         <value>English</value>
     </data>
     <data name="Languages_Russian" xml:space="preserve">
-        <value>Russian</value>
+        <value>Русский</value>
     </data>
     <data name="InfoAlert_ChangeLanguage_Title" xml:space="preserve">
         <value>Warning</value>
@@ -322,7 +322,7 @@
         <value>Cannot find profile with specified ID</value>
     </data>
     <data name="ProfileSettings_ChangeAlert_Title" xml:space="preserve">
-        <value>Change current profile</value>
+        <value>Change Current Profile</value>
     </data>
     <data name="ProfileSettings_ChangeAlert_Desription" xml:space="preserve">
         <value>Are you sure you want to set profile "{0}" current?</value>
@@ -503,5 +503,62 @@
     </data>
     <data name="Settings_GitHub" xml:space="preserve">
         <value>GitHub</value>
+    </data>
+    <data name="CategoriesSettings_DeleteAlert_Title" xml:space="preserve">
+        <value>Delete Category</value>
+    </data>
+    <data name="CategoriesSettings_DeleteAlert_Ok" xml:space="preserve">
+        <value>OK</value>
+    </data>
+    <data name="CategoriesSettings_DeleteAlert_Cancel" xml:space="preserve">
+        <value>Cancel</value>
+    </data>
+    <data name="CategoriesSettings_DeleteAlert_Description" xml:space="preserve">
+        <value>Are you sure you want to delete category "{0}"?</value>
+    </data>
+    <data name="Transactions_DeleteAlert_Cancel" xml:space="preserve">
+        <value>Cancel</value>
+    </data>
+    <data name="Transactions_DeleteAlert_Ok" xml:space="preserve">
+        <value>OK</value>
+    </data>
+    <data name="Transactions_DeleteAlert_Title" xml:space="preserve">
+        <value>Delete Transaction</value>
+    </data>
+    <data name="Transactions_DeleteAlert_Description" xml:space="preserve">
+        <value>Are you sure you want to delete transaction "{0}"?</value>
+    </data>
+    <data name="Transactions_EditNotInPeriodAlert_Cancel" xml:space="preserve">
+        <value>Cancel</value>
+    </data>
+    <data name="Transactions_EditNotInPeriodAlert_Ok" xml:space="preserve">
+        <value>OK</value>
+    </data>
+    <data name="Transactions_EditNotInPeriodAlert_Description" xml:space="preserve">
+        <value>Are you sure you want to edit transaction "{0}"? It is not in the current profile period and does not affect on profile calculation.</value>
+    </data>
+    <data name="Transactions_EditNotInPeriodAlert_Title" xml:space="preserve">
+        <value>Transaction is not in Profile Period</value>
+    </data>
+    <data name="ProfileSettings_DeleteAlert_Cancel" xml:space="preserve">
+        <value>Cancel</value>
+    </data>
+    <data name="ProfileSettings_DeleteAlert_Ok" xml:space="preserve">
+        <value>OK</value>
+    </data>
+    <data name="ProfileSettings_DeleteAlert_Description" xml:space="preserve">
+        <value>Are you sure you want to delete profile "{0}"? All the profile's categories and transactions will be deleted too.</value>
+    </data>
+    <data name="ProfileSettings_DeleteAlert_Title" xml:space="preserve">
+        <value>Delete Profile</value>
+    </data>
+    <data name="ProfileSettings_LastProfileErrorAlert_Title" xml:space="preserve">
+        <value>Last Profile</value>
+    </data>
+    <data name="ProfileSettings_LastProfileErrorAlert_Description" xml:space="preserve">
+        <value>Profile "{0}" is the last profile and you cannot delete it.</value>
+    </data>
+    <data name="ProfileSettings_LastProfileErrorAlert_Ok" xml:space="preserve">
+        <value>OK</value>
     </data>
 </root>

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.ru.Designer.cs
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.ru.Designer.cs
@@ -1016,5 +1016,119 @@ namespace Profitocracy.Mobile.Resources.Strings {
                 return ResourceManager.GetString("Settings_GitHub", resourceCulture);
             }
         }
+        
+        internal static string Transactions_DeleteAlert_Ok {
+            get {
+                return ResourceManager.GetString("Transactions_DeleteAlert_Ok", resourceCulture);
+            }
+        }
+        
+        internal static string Transactions_DeleteAlert_Cancel {
+            get {
+                return ResourceManager.GetString("Transactions_DeleteAlert_Cancel", resourceCulture);
+            }
+        }
+        
+        internal static string Transactions_DeleteAlert_Description {
+            get {
+                return ResourceManager.GetString("Transactions_DeleteAlert_Description", resourceCulture);
+            }
+        }
+        
+        internal static string Transactions_DeleteAlert_Title {
+            get {
+                return ResourceManager.GetString("Transactions_DeleteAlert_Title", resourceCulture);
+            }
+        }
+        
+        internal static string CategoriesSettings_DeleteAlert_Cancel {
+            get {
+                return ResourceManager.GetString("CategoriesSettings_DeleteAlert_Cancel", resourceCulture);
+            }
+        }
+        
+        internal static string CategoriesSettings_DeleteAlert_Ok {
+            get {
+                return ResourceManager.GetString("CategoriesSettings_DeleteAlert_Ok", resourceCulture);
+            }
+        }
+        
+        internal static string CategoriesSettings_DeleteAlert_Title {
+            get {
+                return ResourceManager.GetString("CategoriesSettings_DeleteAlert_Title", resourceCulture);
+            }
+        }
+        
+        internal static string CategoriesSettings_DeleteAlert_Description {
+            get {
+                return ResourceManager.GetString("CategoriesSettings_DeleteAlert_Description", resourceCulture);
+            }
+        }
+        
+        internal static string Transactions_EditNotInPeriodAlert_Cancel {
+            get {
+                return ResourceManager.GetString("Transactions_EditNotInPeriodAlert_Cancel", resourceCulture);
+            }
+        }
+        
+        internal static string Transactions_EditNotInPeriodAlert_Title {
+            get {
+                return ResourceManager.GetString("Transactions_EditNotInPeriodAlert_Title", resourceCulture);
+            }
+        }
+        
+        internal static string Transactions_EditNotInPeriodAlert_Ok {
+            get {
+                return ResourceManager.GetString("Transactions_EditNotInPeriodAlert_Ok", resourceCulture);
+            }
+        }
+        
+        internal static string Transactions_EditNotInPeriodAlert_Description {
+            get {
+                return ResourceManager.GetString("Transactions_EditNotInPeriodAlert_Description", resourceCulture);
+            }
+        }
+        
+        internal static string ProfileSettings_DeleteAlert_Cancel {
+            get {
+                return ResourceManager.GetString("ProfileSettings_DeleteAlert_Cancel", resourceCulture);
+            }
+        }
+        
+        internal static string ProfileSettings_DeleteAlert_Description {
+            get {
+                return ResourceManager.GetString("ProfileSettings_DeleteAlert_Description", resourceCulture);
+            }
+        }
+        
+        internal static string ProfileSettings_DeleteAlert_Ok {
+            get {
+                return ResourceManager.GetString("ProfileSettings_DeleteAlert_Ok", resourceCulture);
+            }
+        }
+        
+        internal static string ProfileSettings_DeleteAlert_Title {
+            get {
+                return ResourceManager.GetString("ProfileSettings_DeleteAlert_Title", resourceCulture);
+            }
+        }
+        
+        internal static string ProfileSettings_LastProfileErrorAlert_Description {
+            get {
+                return ResourceManager.GetString("ProfileSettings_LastProfileErrorAlert_Description", resourceCulture);
+            }
+        }
+        
+        internal static string ProfileSettings_LastProfileErrorAlert_Ok {
+            get {
+                return ResourceManager.GetString("ProfileSettings_LastProfileErrorAlert_Ok", resourceCulture);
+            }
+        }
+        
+        internal static string ProfileSettings_LastProfileErrorAlert_Title {
+            get {
+                return ResourceManager.GetString("ProfileSettings_LastProfileErrorAlert_Title", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.ru.resx
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.ru.resx
@@ -139,7 +139,7 @@
         <value>Системная</value>
     </data>
     <data name="Languages_English" xml:space="preserve">
-        <value>Английский</value>
+        <value>English</value>
     </data>
     <data name="Languages_Russian" xml:space="preserve">
         <value>Русский</value>
@@ -503,5 +503,62 @@
     </data>
     <data name="Settings_GitHub" xml:space="preserve">
         <value>GitHub</value>
+    </data>
+    <data name="Transactions_DeleteAlert_Ok" xml:space="preserve">
+        <value>Да</value>
+    </data>
+    <data name="Transactions_DeleteAlert_Cancel" xml:space="preserve">
+        <value>Отмена</value>
+    </data>
+    <data name="Transactions_DeleteAlert_Description" xml:space="preserve">
+        <value>Вы уверены, что хотите удалить транзакцию "{0}"?</value>
+    </data>
+    <data name="Transactions_DeleteAlert_Title" xml:space="preserve">
+        <value>Удаление транзакции</value>
+    </data>
+    <data name="CategoriesSettings_DeleteAlert_Cancel" xml:space="preserve">
+        <value>Отмена</value>
+    </data>
+    <data name="CategoriesSettings_DeleteAlert_Ok" xml:space="preserve">
+        <value>Да</value>
+    </data>
+    <data name="CategoriesSettings_DeleteAlert_Title" xml:space="preserve">
+        <value>Удаление категории</value>
+    </data>
+    <data name="CategoriesSettings_DeleteAlert_Description" xml:space="preserve">
+        <value>Вы уверены, что хотите удалить категорию "{0}"?</value>
+    </data>
+    <data name="Transactions_EditNotInPeriodAlert_Cancel" xml:space="preserve">
+        <value>Отмена</value>
+    </data>
+    <data name="Transactions_EditNotInPeriodAlert_Title" xml:space="preserve">
+        <value>Транзакция не в периоде профиля</value>
+    </data>
+    <data name="Transactions_EditNotInPeriodAlert_Ok" xml:space="preserve">
+        <value>Да</value>
+    </data>
+    <data name="Transactions_EditNotInPeriodAlert_Description" xml:space="preserve">
+        <value>Вы уверены, что хотите отредактировать транзакцию "{0}"? Она не в текущем периоде профиля и не влияет на расчеты профиля.</value>
+    </data>
+    <data name="ProfileSettings_DeleteAlert_Cancel" xml:space="preserve">
+        <value>Отмена</value>
+    </data>
+    <data name="ProfileSettings_DeleteAlert_Description" xml:space="preserve">
+        <value>Вы уверены, что хотите удалить профиль "{0}"? Все транзакции и категории этого профиля также будут удалены.</value>
+    </data>
+    <data name="ProfileSettings_DeleteAlert_Ok" xml:space="preserve">
+        <value>Да</value>
+    </data>
+    <data name="ProfileSettings_DeleteAlert_Title" xml:space="preserve">
+        <value>Удаление профиля</value>
+    </data>
+    <data name="ProfileSettings_LastProfileErrorAlert_Description" xml:space="preserve">
+        <value>Профиль "{0}" является последним профилем и не может быть удален.</value>
+    </data>
+    <data name="ProfileSettings_LastProfileErrorAlert_Ok" xml:space="preserve">
+        <value>ОК</value>
+    </data>
+    <data name="ProfileSettings_LastProfileErrorAlert_Title" xml:space="preserve">
+        <value>Последний профиль</value>
     </data>
 </root>

--- a/src/Profitocracy.Mobile/ViewModels/Profiles/EditProfilePageViewModel.cs
+++ b/src/Profitocracy.Mobile/ViewModels/Profiles/EditProfilePageViewModel.cs
@@ -18,6 +18,8 @@ public class EditProfilePageViewModel : BaseNotifyObject
     private Currency _currency;
     private bool _isCurrent;
 
+    private bool _isNotFirstProfile = true;
+    
     private readonly IProfileRepository _profileRepository;
     
     public EditProfilePageViewModel(IProfileRepository profileRepository)
@@ -34,6 +36,12 @@ public class EditProfilePageViewModel : BaseNotifyObject
     public Guid? ProfileId
     {
         set => _profileId = value;
+    }
+
+    public bool IsNotFirstProfile
+    {
+        get => _isNotFirstProfile;
+        private set => SetProperty(ref _isNotFirstProfile, value);
     }
     
     public string Name
@@ -61,6 +69,7 @@ public class EditProfilePageViewModel : BaseNotifyObject
         var existingProfiles = await _profileRepository.GetAllProfiles();
         _isCurrent = !existingProfiles.Any(p => p.IsCurrent && p.Id != _profileId);
         
+        IsNotFirstProfile = existingProfiles.Count != 0;
         SelectedCurrency = AvailableCurrencies[0];
 
         if (_profileId is not null)

--- a/src/Profitocracy.Mobile/ViewModels/Profiles/ProfileSettingsPageViewModel.cs
+++ b/src/Profitocracy.Mobile/ViewModels/Profiles/ProfileSettingsPageViewModel.cs
@@ -38,6 +38,12 @@ public class ProfileSettingsPageViewModel : BaseNotifyObject
         }
     }
 
+    public async Task DeleteProfile(Guid profileId)
+    {
+        await _profileService.DeleteProfile(profileId);
+        await Initialize();
+    }
+
     public async Task SetCurrentProfile(Guid profileId)
     {
         await _profileService.SetCurrentProfile(profileId);

--- a/src/Profitocracy.Mobile/ViewModels/Transactions/TransactionsPageViewModel.cs
+++ b/src/Profitocracy.Mobile/ViewModels/Transactions/TransactionsPageViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using Profitocracy.Core.Domain.Abstractions.Services;
 using Profitocracy.Core.Persistence;
 using Profitocracy.Core.Specifications;
 using Profitocracy.Mobile.Abstractions;
@@ -11,6 +12,7 @@ public class TransactionsPageViewModel : BaseNotifyObject
 {
     private readonly ITransactionRepository _transactionRepository;
     private readonly IProfileRepository _profileRepository;
+    private readonly ITransactionService _transactionService;
     
     private Guid? _profileId;
     private DateTime _fromDate;
@@ -18,9 +20,11 @@ public class TransactionsPageViewModel : BaseNotifyObject
     
     public TransactionsPageViewModel(
         IProfileRepository profileRepository,
-        ITransactionRepository transactionRepository)
+        ITransactionRepository transactionRepository, 
+        ITransactionService transactionService)
     {
         _transactionRepository = transactionRepository;
+        _transactionService = transactionService;
         _profileRepository = profileRepository;
         
         var currentDate = DateTime.Now;
@@ -80,6 +84,11 @@ public class TransactionsPageViewModel : BaseNotifyObject
         var deletedId = await _transactionRepository.Delete(transactionId);
 
         Transactions.Remove(Transactions.Single(t => t.Id == deletedId));
+    }
+
+    public Task<bool> IsTransactionInProfilePeriod(Guid transactionId)
+    {
+        return _transactionService.CheckTransactionInCurrentPeriod(transactionId);
     }
 
     private async Task InitializeTransactions()

--- a/src/Profitocracy.Mobile/Views/Settings/CategoriesSettings/EditExpenseCategoryPage.xaml
+++ b/src/Profitocracy.Mobile/Views/Settings/CategoriesSettings/EditExpenseCategoryPage.xaml
@@ -2,6 +2,7 @@
 
 <abstractions:BaseContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
                               xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                              xmlns:ios="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;assembly=Microsoft.Maui.Controls"
                               xmlns:resx="clr-namespace:Profitocracy.Mobile.Resources.Strings"
                               xmlns:abstractions="clr-namespace:Profitocracy.Mobile.Abstractions"
                               xmlns:viewmodel="clr-namespace:Profitocracy.Mobile.ViewModels.Categories"
@@ -9,6 +10,7 @@
                               x:DataType="viewmodel:EditExpenseCategoryPageViewModel"
                               Padding="16"
                               Shell.PresentationMode="ModalAnimated"
+                              ios:Page.ModalPresentationStyle="PageSheet"
                               Loaded="EditExpenseCategoryPage_OnLoaded"
                               HideSoftInputOnTapped="True">
     <abstractions:BaseContentPage.Content>
@@ -28,32 +30,37 @@
                            Text="X"/>
                 </Border>
             </FlexLayout>
-            <StackLayout Grid.Row="1">
-                <StackLayout Margin="0,32,0,0">
-                    <Label Text="{x:Static resx:AppResources.AddCategory_CategoryName}"/>
-                    <Entry Margin="0,4,0,0"
-                           Text="{Binding Name, Mode=TwoWay}"/>
+            
+            <ScrollView Grid.Row="1">
+                <StackLayout>
+                    <StackLayout Margin="0,32,0,0">
+                        <Label Text="{x:Static resx:AppResources.AddCategory_CategoryName}"/>
+                        <Entry Margin="0,4,0,0"
+                               Text="{Binding Name, Mode=TwoWay}"/>
+                    </StackLayout>
+                
+                    <FlexLayout Margin="0,16,0,0"
+                                JustifyContent="SpaceBetween">
+                        <Label Text="{x:Static resx:AppResources.AddCategory_SpecifyPlannedAmount}" 
+                               VerticalTextAlignment="Center"/>
+                        <Switch IsToggled="{Binding IsPlannedAmountPresent, Mode=TwoWay}"/>    
+                    </FlexLayout>
+                
+                
+                    <StackLayout Margin="0,16,0,0"
+                                 IsVisible="{Binding IsPlannedAmountPresent}">
+                        <Label Text="{x:Static resx:AppResources.AddCategory_PlannedAmount}"/>
+                        <Entry Margin="0,4,0,0"
+                               Keyboard="Numeric"
+                               Text="{Binding PlannedAmount, Mode=TwoWay}"/>    
+                    </StackLayout>
                 </StackLayout>
-                
-                <FlexLayout Margin="0,16,0,0"
-                            JustifyContent="SpaceBetween">
-                    <Label Text="{x:Static resx:AppResources.AddCategory_SpecifyPlannedAmount}" 
-                           VerticalTextAlignment="Center"/>
-                    <Switch IsToggled="{Binding IsPlannedAmountPresent, Mode=TwoWay}"/>    
-                </FlexLayout>
-                
-                
-                <StackLayout Margin="0,16,0,0"
-                             IsVisible="{Binding IsPlannedAmountPresent}">
-                    <Label Text="{x:Static resx:AppResources.AddCategory_PlannedAmount}"/>
-                    <Entry Margin="0,4,0,0"
-                           Keyboard="Numeric"
-                           Text="{Binding PlannedAmount, Mode=TwoWay}"/>    
-                </StackLayout>
-            </StackLayout>
+            </ScrollView>
+            
             <Button Grid.Row="2"
                     Text="{x:Static resx:AppResources.AddCategory_SaveCategory}"
                     x:Name="AddCategoryButton"
+                    VerticalOptions="End"
                     Clicked="AddCategoryButton_OnClicked"/>
         </Grid>
     </abstractions:BaseContentPage.Content>

--- a/src/Profitocracy.Mobile/Views/Settings/CategoriesSettings/ExpenseCategoriesSettingsPage.xaml
+++ b/src/Profitocracy.Mobile/Views/Settings/CategoriesSettings/ExpenseCategoriesSettingsPage.xaml
@@ -11,7 +11,7 @@
                               Title="{x:Static resx:AppResources.Pages_Categories}"
                               BackgroundColor="{AppThemeBinding Light={StaticResource LightBackground}, Dark={StaticResource DarkBackground}}"
                               NavigatedTo="UpdateCategoriesList"
-                              Padding="8"
+                              Padding="8,0,8,0"
                               HideSoftInputOnTapped="True">
     <abstractions:BaseContentPage.Content>
         <Grid>
@@ -19,64 +19,68 @@
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
             
-            <ScrollView Grid.Row="0">
-                <CollectionView x:Name="CategoriesCollectionView">
-                    <CollectionView.ItemTemplate>
-                        <DataTemplate x:DataType="categories:CategoryModel">
-                            <SwipeView>
-                                <SwipeView.RightItems>
-                                    <SwipeItems>
-                                        <SwipeItemView Padding="4,0,8,0"
-                                                       BackgroundColor="Transparent"
-                                                       Invoked="DeleteCategory_OnInvoked">
-                                            <VerticalStackLayout VerticalOptions="Center" 
-                                                                 Width="16">
-                                                <Border BackgroundColor="{StaticResource DangerRed}"
-                                                        StrokeThickness="0"
-                                                        Padding="16">
-                                                    <Border.StrokeShape>
-                                                        <RoundRectangle CornerRadius="40"/>
-                                                    </Border.StrokeShape>
-                                                    <Image Source="bin.png" 
-                                                           Width="8"/>
-                                                </Border>
-                                            </VerticalStackLayout>
-                                        </SwipeItemView>
-                                        <SwipeItemView Padding="8,0,4,0"
-                                                       BackgroundColor="Transparent"
-                                                       Invoked="EditCategory_OnInvoked">
-                                            <VerticalStackLayout VerticalOptions="Center" 
-                                                                 Width="16">
-                                                <Border BackgroundColor="{StaticResource InfoBlue}"
-                                                        StrokeThickness="0"
-                                                        Padding="16">
-                                                    <Border.StrokeShape>
-                                                        <RoundRectangle CornerRadius="40"/>
-                                                    </Border.StrokeShape>
-                                                    <Image Source="edit.png" 
-                                                           Width="8"/>
-                                                </Border>
-                                            </VerticalStackLayout>
-                                        </SwipeItemView>
-                                    </SwipeItems>
-                                </SwipeView.RightItems>
-                                
-                                <Border Style="{StaticResource CategoryCard}"
-                                        Margin="0,8,0,0">
-                                    <StackLayout>
-                                        <FlexLayout JustifyContent="SpaceBetween">
-                                            <Label Style="{StaticResource CategoryCardName}"
-                                                   Text="{Binding Name}"/>
-                                            <Label Style="{StaticResource CategoryCardPlannedAmount}"
-                                                   Text="{Binding DisplayPlannedAmount}"/>
-                                        </FlexLayout>
-                                    </StackLayout>
-                                </Border>
-                            </SwipeView>
-                        </DataTemplate>
-                    </CollectionView.ItemTemplate>
-                </CollectionView>
-            </ScrollView>
+            <CollectionView Grid.Row="0"
+                            x:Name="CategoriesCollectionView"
+                            VerticalScrollBarVisibility="Never">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate x:DataType="categories:CategoryModel">
+                        <SwipeView>
+                            <SwipeView.RightItems>
+                                <SwipeItems>
+                                    <SwipeItemView Padding="4,0,8,0"
+                                                   BackgroundColor="Transparent"
+                                                   Invoked="DeleteCategory_OnInvoked">
+                                        <VerticalStackLayout VerticalOptions="Center" 
+                                                             Width="16">
+                                            <Border BackgroundColor="{StaticResource DangerRed}"
+                                                    StrokeThickness="0"
+                                                    Padding="16">
+                                                <Border.StrokeShape>
+                                                    <RoundRectangle CornerRadius="40"/>
+                                                </Border.StrokeShape>
+                                                <Image Source="bin.png" 
+                                                       Width="8"/>
+                                            </Border>
+                                        </VerticalStackLayout>
+                                    </SwipeItemView>
+                                    <SwipeItemView Padding="8,0,4,0"
+                                                   BackgroundColor="Transparent"
+                                                   Invoked="EditCategory_OnInvoked">
+                                        <VerticalStackLayout VerticalOptions="Center" 
+                                                             Width="16">
+                                            <Border BackgroundColor="{StaticResource InfoBlue}"
+                                                    StrokeThickness="0"
+                                                    Padding="16">
+                                                <Border.StrokeShape>
+                                                    <RoundRectangle CornerRadius="40"/>
+                                                </Border.StrokeShape>
+                                                <Image Source="edit.png" 
+                                                       Width="8"/>
+                                            </Border>
+                                        </VerticalStackLayout>
+                                    </SwipeItemView>
+                                </SwipeItems>
+                            </SwipeView.RightItems>
+                            
+                            <Border Style="{StaticResource CategoryCard}"
+                                    Margin="0,8,0,0">
+                                <StackLayout>
+                                    <FlexLayout JustifyContent="SpaceBetween">
+                                        <Label Style="{StaticResource CategoryCardName}"
+                                               Text="{Binding Name}"/>
+                                        <Label Style="{StaticResource CategoryCardPlannedAmount}"
+                                               Text="{Binding DisplayPlannedAmount}"/>
+                                    </FlexLayout>
+                                </StackLayout>
+                            </Border>
+                        </SwipeView>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+                <CollectionView.Footer>
+                    <Grid HeightRequest="92"
+                          BackgroundColor="Transparent"/>
+                </CollectionView.Footer>
+            </CollectionView>
             
             <Button Grid.Row="0"
                     Text="+"

--- a/src/Profitocracy.Mobile/Views/Settings/CategoriesSettings/ExpenseCategoriesSettingsPage.xaml.cs
+++ b/src/Profitocracy.Mobile/Views/Settings/CategoriesSettings/ExpenseCategoriesSettingsPage.xaml.cs
@@ -68,8 +68,17 @@ public partial class ExpenseCategoriesSettingsPage : BaseContentPage
 			{
 				throw new ArgumentNullException(AppResources.CommonError_FindCategoryToDelete);
 			}
-			
-			await _viewModel.DeleteCategory((Guid)category.Id);
+
+			var isDelete = await DisplayAlert(
+				AppResources.CategoriesSettings_DeleteAlert_Title,
+				string.Format(AppResources.CategoriesSettings_DeleteAlert_Description, category.Name),
+				AppResources.CategoriesSettings_DeleteAlert_Ok,
+				AppResources.CategoriesSettings_DeleteAlert_Cancel);
+
+			if (isDelete)
+			{
+				await _viewModel.DeleteCategory((Guid)category.Id);	
+			}
 		});
 	}
 	

--- a/src/Profitocracy.Mobile/Views/Settings/ProfilesSettings/EditProfilePage.xaml
+++ b/src/Profitocracy.Mobile/Views/Settings/ProfilesSettings/EditProfilePage.xaml
@@ -26,7 +26,9 @@
                        Text="{x:Static resx:AppResources.EditProfile_Profile}"/>
                 <Border Style="{StaticResource CloseButton}"
                         VerticalOptions="End"
-                        x:Name="CloseButton">
+                        x:Name="CloseButton"
+                        IsEnabled="{Binding IsNotFirstProfile}"
+                        IsVisible="{Binding IsNotFirstProfile}">
                     <Border.GestureRecognizers>
                         <TapGestureRecognizer Tapped="CloseButton_OnClicked" />
                     </Border.GestureRecognizers>
@@ -34,35 +36,38 @@
                            Text="X"/>
                 </Border>
             </FlexLayout>
-            <StackLayout Margin="0,32,0,0"
-                         Grid.Row="1">
+            <ScrollView Grid.Row="1"
+                        Margin="0,32,0,0">
                 <StackLayout>
-                    <Label Text="{x:Static resx:AppResources.EditProfile_ProfileName}"/>
-                    <Entry Margin="0,4,0,0"
-                           Text="{Binding Name, Mode=TwoWay}" />
-                </StackLayout>
+                    <StackLayout>
+                        <Label Text="{x:Static resx:AppResources.EditProfile_ProfileName}"/>
+                        <Entry Margin="0,4,0,0"
+                               Text="{Binding Name, Mode=TwoWay}" />
+                    </StackLayout>
             
-                <StackLayout Margin="0,16,0,0">
-                    <Label Text="{x:Static resx:AppResources.EditProfile_InitialBalance}"/>
-                    <Grid Margin="0,4,0,0">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition />
-                            <ColumnDefinition Width="8"/>
-                            <ColumnDefinition Width="3*" />
-                        </Grid.ColumnDefinitions>
+                    <StackLayout Margin="0,16,0,0">
+                        <Label Text="{x:Static resx:AppResources.EditProfile_InitialBalance}"/>
+                        <Grid Margin="0,4,0,0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition />
+                                <ColumnDefinition Width="8"/>
+                                <ColumnDefinition Width="3*" />
+                            </Grid.ColumnDefinitions>
                                         
-                        <Picker Grid.Column="0"
-                                x:Name="ProfileCurrencyPicker"
-                                SelectedItem="{Binding SelectedCurrency}"
-                                ItemDisplayBinding="{Binding Code}"/>
-                        <Entry Grid.Column="2" Margin="0,4,0,0"
-                               Keyboard="Numeric"
-                               Text="{Binding InitialBalance, Mode=TwoWay}"/>
-                    </Grid>
+                            <Picker Grid.Column="0"
+                                    x:Name="ProfileCurrencyPicker"
+                                    SelectedItem="{Binding SelectedCurrency}"
+                                    ItemDisplayBinding="{Binding Code}"/>
+                            <Entry Grid.Column="2" Margin="0,4,0,0"
+                                   Keyboard="Numeric"
+                                   Text="{Binding InitialBalance, Mode=TwoWay}"/>
+                        </Grid>
+                    </StackLayout>
                 </StackLayout>
-            </StackLayout>
+            </ScrollView>
             
             <Button Grid.Row="2"
+                    VerticalOptions="End"
                     Text="{x:Static resx:AppResources.EditProfile_SaveProfile}" 
                     Clicked="Button_OnClicked"/>
         </Grid>

--- a/src/Profitocracy.Mobile/Views/Settings/ProfilesSettings/ProfilesSettingsPage.xaml
+++ b/src/Profitocracy.Mobile/Views/Settings/ProfilesSettings/ProfilesSettingsPage.xaml
@@ -19,67 +19,86 @@
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
             
-            <ScrollView Grid.Row="0">
-                <CollectionView x:Name="ProfilesCollectionView"
-                                Margin="0,16,0,16">
-                    <CollectionView.ItemTemplate>
-                        <DataTemplate x:DataType="profiles:ProfileModel">
-                            <SwipeView>
-                                <SwipeView.RightItems>
-                                    <SwipeItems>
-                                        <SwipeItemView Padding="8,0,4,0"
-                                                       BackgroundColor="Transparent"
-                                                       Invoked="EditProfile_OnInvoked">
-                                            <VerticalStackLayout VerticalOptions="Center" 
-                                                                 Width="16">
-                                                <Border BackgroundColor="{StaticResource InfoBlue}"
-                                                        StrokeThickness="0"
-                                                        Padding="16">
-                                                    <Border.StrokeShape>
-                                                        <RoundRectangle CornerRadius="40"/>
-                                                    </Border.StrokeShape>
-                                                    <Image Source="edit.png" 
-                                                           Width="8"/>
-                                                </Border>
-                                            </VerticalStackLayout>
-                                        </SwipeItemView>
-                                    </SwipeItems>
-                                </SwipeView.RightItems>
-                                
-                                <StackLayout>
-                                    <Border Style="{StaticResource CurrentProfileCard}"
-                                            Margin="0,8,0,0"
-                                            IsVisible="{Binding IsCurrent}">
-                                        <StackLayout>
-                                            <FlexLayout JustifyContent="SpaceBetween">
-                                                <Label Style="{StaticResource CurrentProfileCardName}"
-                                                       Text="{Binding Name}"/>
-                                                <Label Style="{StaticResource CurrentProfileCardName}"
-                                                       Text="{Binding CurrencySymbol}"/>
-                                            </FlexLayout>
-                                        </StackLayout>
-                                    </Border> 
-                                    <Border Style="{StaticResource ProfileCard}"
-                                            Margin="0,8,0,0"
-                                            IsVisible="{Binding IsNotCurrent}">
-                                        <Border.GestureRecognizers>
-                                            <TapGestureRecognizer Tapped="ProfileCard_OnTapped"/>
-                                        </Border.GestureRecognizers>
-                                        <StackLayout>
-                                            <FlexLayout JustifyContent="SpaceBetween">
-                                                <Label Style="{StaticResource CategoryCardName}"
-                                                       Text="{Binding Name}"/>
-                                                <Label Style="{StaticResource CategoryCardPlannedAmount}"
-                                                       Text="{Binding CurrencySymbol}"/>
-                                            </FlexLayout>
-                                        </StackLayout>
-                                    </Border>
-                                </StackLayout>
-                            </SwipeView>
-                        </DataTemplate>
-                    </CollectionView.ItemTemplate>
-                </CollectionView>
-            </ScrollView>
+            <CollectionView Grid.Row="0"
+                            x:Name="ProfilesCollectionView"
+                            VerticalScrollBarVisibility="Never">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate x:DataType="profiles:ProfileModel">
+                        <SwipeView>
+                            <SwipeView.RightItems>
+                                <SwipeItems>
+                                    <SwipeItemView Padding="4,0,8,0"
+                                                   BackgroundColor="Transparent"
+                                                   Invoked="DeleteProfile_OnInvoked">
+                                        <VerticalStackLayout VerticalOptions="Center" 
+                                                             Width="16">
+                                            <Border BackgroundColor="{StaticResource DangerRed}"
+                                                    StrokeThickness="0"
+                                                    Padding="16">
+                                                <Border.StrokeShape>
+                                                    <RoundRectangle CornerRadius="40"/>
+                                                </Border.StrokeShape>
+                                                <Image Source="bin.png" 
+                                                       Width="8"/>
+                                            </Border>
+                                        </VerticalStackLayout>
+                                    </SwipeItemView>
+                                    <SwipeItemView Padding="8,0,4,0"
+                                                   BackgroundColor="Transparent"
+                                                   Invoked="EditProfile_OnInvoked">
+                                        <VerticalStackLayout VerticalOptions="Center" 
+                                                             Width="16">
+                                            <Border BackgroundColor="{StaticResource InfoBlue}"
+                                                    StrokeThickness="0"
+                                                    Padding="16">
+                                                <Border.StrokeShape>
+                                                    <RoundRectangle CornerRadius="40"/>
+                                                </Border.StrokeShape>
+                                                <Image Source="edit.png" 
+                                                       Width="8"/>
+                                            </Border>
+                                        </VerticalStackLayout>
+                                    </SwipeItemView>
+                                </SwipeItems>
+                            </SwipeView.RightItems>
+                            
+                            <StackLayout>
+                                <Border Style="{StaticResource CurrentProfileCard}"
+                                        Margin="0,8,0,0"
+                                        IsVisible="{Binding IsCurrent}">
+                                    <StackLayout>
+                                        <FlexLayout JustifyContent="SpaceBetween">
+                                            <Label Style="{StaticResource CurrentProfileCardName}"
+                                                   Text="{Binding Name}"/>
+                                            <Label Style="{StaticResource CurrentProfileCardName}"
+                                                   Text="{Binding CurrencySymbol}"/>
+                                        </FlexLayout>
+                                    </StackLayout>
+                                </Border> 
+                                <Border Style="{StaticResource ProfileCard}"
+                                        Margin="0,8,0,0"
+                                        IsVisible="{Binding IsNotCurrent}">
+                                    <Border.GestureRecognizers>
+                                        <TapGestureRecognizer Tapped="ProfileCard_OnTapped"/>
+                                    </Border.GestureRecognizers>
+                                    <StackLayout>
+                                        <FlexLayout JustifyContent="SpaceBetween">
+                                            <Label Style="{StaticResource CategoryCardName}"
+                                                   Text="{Binding Name}"/>
+                                            <Label Style="{StaticResource CategoryCardPlannedAmount}"
+                                                   Text="{Binding CurrencySymbol}"/>
+                                        </FlexLayout>
+                                    </StackLayout>
+                                </Border>
+                            </StackLayout>
+                        </SwipeView>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+                <CollectionView.Footer>
+                    <Grid HeightRequest="92" 
+                          BackgroundColor="Transparent"/>
+                </CollectionView.Footer>
+            </CollectionView>
             
             <Button Grid.Row="0"
                     Text="+"

--- a/src/Profitocracy.Mobile/Views/Settings/ProfilesSettings/ProfilesSettingsPage.xaml.cs
+++ b/src/Profitocracy.Mobile/Views/Settings/ProfilesSettings/ProfilesSettingsPage.xaml.cs
@@ -1,3 +1,4 @@
+using Profitocracy.Core.Exceptions;
 using Profitocracy.Mobile.Abstractions;
 using Profitocracy.Mobile.Models.Profiles;
 using Profitocracy.Mobile.Resources.Strings;
@@ -94,6 +95,45 @@ public partial class ProfilesSettingsPage : BaseContentPage
             if (changeCurrentProfile)
             {
                 await _viewModel.SetCurrentProfile((Guid)profile.Id);
+            }
+        });
+    }
+
+    private void DeleteProfile_OnInvoked(object? sender, EventArgs e)
+    {
+        ProcessAction(async () =>
+        {
+            if (sender is not SwipeItemView swipeItem)
+            {
+                throw new InvalidCastException(AppResources.CommonError_InternalErrorTryAgain);
+            }
+			
+            var profile = swipeItem.BindingContext as ProfileModel;
+
+            if (profile?.Id is null)
+            {
+                throw new ArgumentNullException(AppResources.CommonError_FindCategoryToDelete);
+            }
+
+            var isDelete = await DisplayAlert(
+                AppResources.ProfileSettings_DeleteAlert_Title,
+                string.Format(AppResources.ProfileSettings_DeleteAlert_Description, profile.Name),
+                AppResources.ProfileSettings_DeleteAlert_Ok,
+                AppResources.ProfileSettings_DeleteAlert_Cancel);
+
+            if (isDelete)
+            {
+                try
+                {
+                    await _viewModel.DeleteProfile((Guid)profile.Id);
+                }
+                catch (LastProfileDeletionException ex)
+                {
+                    await DisplayAlert(
+                        AppResources.ProfileSettings_LastProfileErrorAlert_Title,
+                        string.Format(AppResources.ProfileSettings_LastProfileErrorAlert_Description, ex.ProfileName),
+                        AppResources.ProfileSettings_LastProfileErrorAlert_Ok);
+                }
             }
         });
     }

--- a/src/Profitocracy.Mobile/Views/Settings/SettingsPage.xaml.cs
+++ b/src/Profitocracy.Mobile/Views/Settings/SettingsPage.xaml.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using Profitocracy.Mobile.Abstractions;
 using Profitocracy.Mobile.Constants;
 using Profitocracy.Mobile.Views.Settings.CategoriesSettings;
@@ -10,16 +9,10 @@ namespace Profitocracy.Mobile.Views.Settings;
 
 public partial class SettingsPage : BaseContentPage
 {
-	private const string DefaultVersion = "0.0.0"; 
-	
 	public SettingsPage()
 	{
 		InitializeComponent();
-		VersionLabel.Text = Assembly
-			.GetExecutingAssembly()
-			.GetName()
-			.Version?
-			.ToString() ?? DefaultVersion;
+		VersionLabel.Text = AppInfo.VersionString;
 	}
 
 	private void ProfilesButton_OnClicked(object? sender, TappedEventArgs e)

--- a/src/Profitocracy.Mobile/Views/Transactions/EditTransactionPage.xaml
+++ b/src/Profitocracy.Mobile/Views/Transactions/EditTransactionPage.xaml
@@ -2,6 +2,7 @@
 
 <abstractions:BaseContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
                               xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                              xmlns:ios="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;assembly=Microsoft.Maui.Controls"
                               xmlns:resx="clr-namespace:Profitocracy.Mobile.Resources.Strings"
                               xmlns:abstractions="clr-namespace:Profitocracy.Mobile.Abstractions"
                               xmlns:viewmodel="clr-namespace:Profitocracy.Mobile.ViewModels.Transactions"
@@ -9,6 +10,7 @@
                               x:DataType="viewmodel:EditTransactionPageViewModel"
                               Loaded="EditTransactionPage_OnLoaded"
                               Shell.PresentationMode="ModalAnimated"
+                              ios:Page.ModalPresentationStyle="PageSheet"
                               Padding="16"
                               HideSoftInputOnTapped="True">
     <Grid VerticalOptions="Fill"

--- a/src/Profitocracy.Mobile/Views/Transactions/FilteredTransactionsPage.xaml
+++ b/src/Profitocracy.Mobile/Views/Transactions/FilteredTransactionsPage.xaml
@@ -2,6 +2,7 @@
 
 <abstractions:BaseContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
                               xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                              xmlns:ios="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;assembly=Microsoft.Maui.Controls"
                               xmlns:resx="clr-namespace:Profitocracy.Mobile.Resources.Strings"
                               xmlns:transactions="clr-namespace:Profitocracy.Mobile.Models.Transactions"
                               xmlns:abstractions="clr-namespace:Profitocracy.Mobile.Abstractions"
@@ -9,6 +10,7 @@
                               x:Class="Profitocracy.Mobile.Views.Transactions.FilteredTransactionsPage"
                               x:DataType="viewmodel:FilteredTransactionsPageViewModel"
                               Shell.PresentationMode="ModalAnimated"
+                              ios:Page.ModalPresentationStyle="PageSheet"
                               HideSoftInputOnTapped="True">
     <abstractions:BaseContentPage.Content>
         <Grid>

--- a/src/Profitocracy.Mobile/Views/Transactions/TransactionsPage.xaml
+++ b/src/Profitocracy.Mobile/Views/Transactions/TransactionsPage.xaml
@@ -54,7 +54,9 @@
             </StackLayout>
         </Border>
         
-        <CollectionView Grid.Row="1" x:Name="TransactionsCollectionView">
+        <CollectionView Grid.Row="1" 
+                        x:Name="TransactionsCollectionView"
+                        VerticalScrollBarVisibility="Default">
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="transactions:TransactionModel">
                     <SwipeView>
@@ -154,6 +156,10 @@
                     </SwipeView>
                 </DataTemplate>
             </CollectionView.ItemTemplate>
+            <CollectionView.Footer>
+                <Grid HeightRequest="92" 
+                      BackgroundColor="Transparent"/>
+            </CollectionView.Footer>
         </CollectionView>
         
         <Button Grid.Row="1"

--- a/src/Profitocracy.Mobile/Views/Transactions/TransactionsPage.xaml.cs
+++ b/src/Profitocracy.Mobile/Views/Transactions/TransactionsPage.xaml.cs
@@ -56,7 +56,16 @@ public partial class TransactionsPage : BaseContentPage
 				throw new ArgumentNullException(AppResources.CommonError_FindTransactionToDelete);
 			}
 		
-			await _viewModel.DeleteTransaction((Guid)transaction.Id);
+			var isDelete = await DisplayAlert(
+				AppResources.Transactions_DeleteAlert_Title,
+				string.Format(AppResources.Transactions_DeleteAlert_Description, transaction.Description),
+				AppResources.Transactions_DeleteAlert_Ok,
+				AppResources.Transactions_DeleteAlert_Cancel);
+
+			if (isDelete)
+			{
+				await _viewModel.DeleteTransaction((Guid)transaction.Id);	
+			}
 		});
 	}
 
@@ -75,6 +84,23 @@ public partial class TransactionsPage : BaseContentPage
 			{
 				throw new ArgumentNullException(AppResources.CommonError_FindTransactionToEdit);
 			}
+
+			var isTransactionInPeriod = await _viewModel.IsTransactionInProfilePeriod((Guid)transaction.Id);
+			var isEdit = true;
+			
+			if (!isTransactionInPeriod)
+			{
+				isEdit = await DisplayAlert(
+					AppResources.Transactions_EditNotInPeriodAlert_Title,
+					string.Format(AppResources.Transactions_EditNotInPeriodAlert_Description, transaction.Description),
+					AppResources.Transactions_EditNotInPeriodAlert_Ok,
+					AppResources.Transactions_EditNotInPeriodAlert_Cancel);
+			}
+
+			if (!isEdit)
+			{
+				return;
+			}
 			
 			var editPage = Handler?.MauiContext?.Services.GetService<EditTransactionPage>();
 
@@ -84,7 +110,6 @@ public partial class TransactionsPage : BaseContentPage
 			}
 		
 			editPage.AddTransactionId((Guid)transaction.Id);
-			
 			await Navigation.PushModalAsync(editPage);
 		});
 	}


### PR DESCRIPTION
- Fixed #33 
- Calculations of daily amounts in case of negative balance
- Additional and main display amounts are swapped for multi currency transactions
- Plus button at profiles, categories and transactions pages now does not overflow the content
- Added ability to delete a profile
- Added deletion confirmation for profiles, transactions and categories
- Added a warning alert on editing a transaction which timestamp is out of billing period of the current profile
- On iOS made some pages as `PageSheet`
- Made ProfileEditingPage non-closable if a profile is the first (setup process)
- Added new strings to resources
- Some minor improvements such as using `ValueTask` instead of a `Task` in `DbConnection`