### PR TITLE
Import/Export feature implementation

### DIFF
--- a/src/Profitocracy.Core/Integrations/IBackupProvider.cs
+++ b/src/Profitocracy.Core/Integrations/IBackupProvider.cs
@@ -18,9 +18,10 @@ public interface IBackupProvider
     /// The stream containing the backup data to import.
     /// </param>
     /// <returns>
-    /// A task representing the asynchronous operation.
+    /// Returns the current index of an importing object
+    /// and the total amount of objects to import on each iteration.
     /// </returns>
-    Task ImportDataAsync(Stream backupFileStream);
+    IAsyncEnumerable<(int Current, int Total)> ImportDataAsync(Stream backupFileStream);
 
     /// <summary>
     /// Asynchronously exports backup data to a stream based on the specified inclusion options.

--- a/src/Profitocracy.Core/Integrations/IBackupProvider.cs
+++ b/src/Profitocracy.Core/Integrations/IBackupProvider.cs
@@ -1,0 +1,41 @@
+namespace Profitocracy.Core.Integrations;
+
+/// <summary>
+/// Defines methods for importing and exporting backup data within the app.
+/// </summary>
+public interface IBackupProvider
+{
+    /// <summary>
+    /// Gets the file extension used for backup files
+    /// generated or processed by the backup provider.
+    /// </summary>
+    string BackupFileExtension { get; }
+
+    /// <summary>
+    /// Asynchronously imports backup data from the provided stream.
+    /// </summary>
+    /// <param name="backupFileStream">
+    /// The stream containing the backup data to import.
+    /// </param>
+    /// <returns>
+    /// A task representing the asynchronous operation.
+    /// </returns>
+    Task ImportDataAsync(Stream backupFileStream);
+
+    /// <summary>
+    /// Asynchronously exports backup data to a stream based on the specified inclusion options.
+    /// </summary>
+    /// <param name="includeProfiles">
+    /// Indicates whether to include profile data in the exported backup.
+    /// </param>
+    /// <param name="includeCategories">
+    /// Indicates whether to include category data in the exported backup.
+    /// </param>
+    /// <param name="includeTransactions">
+    /// Indicates whether to include transaction data in the exported backup.
+    /// </param>
+    /// <returns>
+    /// The stream with the exported backup data.
+    /// </returns>
+    Task<Stream> ExportDataAsync(bool includeProfiles, bool includeCategories, bool includeTransactions);
+}

--- a/src/Profitocracy.Core/Profitocracy.Core.csproj
+++ b/src/Profitocracy.Core/Profitocracy.Core.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.2" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.7" />
     </ItemGroup>
 
 </Project>

--- a/src/Profitocracy.Infrastructure/InfrastructureRegistry.cs
+++ b/src/Profitocracy.Infrastructure/InfrastructureRegistry.cs
@@ -57,6 +57,9 @@ public static class InfrastructureRegistry
             .AddTransient<ITransactionRepository, TransactionRepository>()
             .AddTransient<IProfileRepository, ProfileRepository>()
             .AddTransient<ICategoryRepository, CategoryRepository>()
+            .AddTransient<TransactionRepository>(sp => (TransactionRepository)sp.GetRequiredService<ITransactionRepository>())
+            .AddTransient<ProfileRepository>(sp => (ProfileRepository)sp.GetRequiredService<IProfileRepository>())
+            .AddTransient<CategoryRepository>(sp => (CategoryRepository)sp.GetRequiredService<ICategoryRepository>())
             .AddTransient<ISettingsRepository, SettingsRepository>();
     }
 }

--- a/src/Profitocracy.Infrastructure/InfrastructureRegistry.cs
+++ b/src/Profitocracy.Infrastructure/InfrastructureRegistry.cs
@@ -31,7 +31,8 @@ public static class InfrastructureRegistry
     private static IServiceCollection RegisterIntegrationsServices(this IServiceCollection services)
     {
         return services
-            .AddTransient<ISecurityProvider, SecurityProvider>();
+            .AddTransient<ISecurityProvider, SecurityProvider>()
+            .AddTransient<IBackupProvider, BackupProvider>();
     }
 
     private static IServiceCollection RegisterPersistence(this IServiceCollection services, InfrastructureConfiguration configuration)

--- a/src/Profitocracy.Infrastructure/Integrations/BackupProvider.cs
+++ b/src/Profitocracy.Infrastructure/Integrations/BackupProvider.cs
@@ -1,0 +1,22 @@
+using Profitocracy.Core.Integrations;
+using System.Text;
+
+namespace Profitocracy.Infrastructure.Integrations;
+
+internal sealed class BackupProvider : IBackupProvider
+{
+    public string BackupFileExtension => "pfc.v1.backup";
+
+    public Task ImportDataAsync(Stream backupFileStream)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task<Stream> ExportDataAsync(bool includeProfiles, bool includeCategories, bool includeTransactions)
+    {
+        const string testStr = "Hello, this is a test backup file.";
+
+        var stream = new MemoryStream(Encoding.UTF8.GetBytes(testStr));
+        return Task.FromResult<Stream>(stream);
+    }
+}

--- a/src/Profitocracy.Infrastructure/Integrations/Models/BackupModel.cs
+++ b/src/Profitocracy.Infrastructure/Integrations/Models/BackupModel.cs
@@ -1,0 +1,12 @@
+using Profitocracy.Infrastructure.Persistence.Sqlite.Models.Category;
+using Profitocracy.Infrastructure.Persistence.Sqlite.Models.Profile;
+using Profitocracy.Infrastructure.Persistence.Sqlite.Models.Transaction;
+
+namespace Profitocracy.Infrastructure.Integrations.Models;
+
+public class BackupModelV1
+{
+    public List<ProfileModel>? Profiles { get; set; }
+    public List<CategoryModel>? Categories { get; set; }
+    public List<TransactionModel>? Transactions { get; set; }
+}

--- a/src/Profitocracy.Infrastructure/Persistence/Sqlite/Models/Category/CategoryModel.cs
+++ b/src/Profitocracy.Infrastructure/Persistence/Sqlite/Models/Category/CategoryModel.cs
@@ -2,7 +2,7 @@ using SQLite;
 
 namespace Profitocracy.Infrastructure.Persistence.Sqlite.Models.Category;
 
-internal class CategoryModel
+public class CategoryModel
 {
     [PrimaryKey]
     public Guid Id { get; set; }

--- a/src/Profitocracy.Infrastructure/Persistence/Sqlite/Models/Profile/ProfileCategoryModel.cs
+++ b/src/Profitocracy.Infrastructure/Persistence/Sqlite/Models/Profile/ProfileCategoryModel.cs
@@ -1,6 +1,6 @@
 namespace Profitocracy.Infrastructure.Persistence.Sqlite.Models.Profile;
 
-internal class ProfileCategoryModel
+public class ProfileCategoryModel
 {
     public Guid CategoryId { get; set; }
 

--- a/src/Profitocracy.Infrastructure/Persistence/Sqlite/Models/Profile/ProfileModel.cs
+++ b/src/Profitocracy.Infrastructure/Persistence/Sqlite/Models/Profile/ProfileModel.cs
@@ -2,7 +2,7 @@ using SQLite;
 
 namespace Profitocracy.Infrastructure.Persistence.Sqlite.Models.Profile;
 
-internal class ProfileModel
+public class ProfileModel
 {
     [PrimaryKey]
     public Guid Id { get; set; }

--- a/src/Profitocracy.Infrastructure/Persistence/Sqlite/Models/Transaction/TransactionModel.cs
+++ b/src/Profitocracy.Infrastructure/Persistence/Sqlite/Models/Transaction/TransactionModel.cs
@@ -4,9 +4,9 @@ namespace Profitocracy.Infrastructure.Persistence.Sqlite.Models.Transaction;
 
 /// <summary>
 /// Persistence representation for
-/// <see cref="Profitocracy.Core.Domain.Model.Transactions.Transaction"/> domain model 
+/// <see cref="Profitocracy.Core.Domain.Model.Transactions.Transaction"/> domain model
 /// </summary>
-internal class TransactionModel
+public class TransactionModel
 {
     [PrimaryKey]
     public Guid Id { get; set; }

--- a/src/Profitocracy.Infrastructure/Persistence/Sqlite/Repositories/CategoryRepository.cs
+++ b/src/Profitocracy.Infrastructure/Persistence/Sqlite/Repositories/CategoryRepository.cs
@@ -41,17 +41,21 @@ internal class CategoryRepository : ICategoryRepository
 
     public async Task<Category> Create(Category category)
     {
-        await _dbConnection.Init();
-
         var categoryToCreate = _mapper.MapToModel(category);
-        await _dbConnection.Database.InsertAsync(categoryToCreate);
-
-        var createdCategory = await _dbConnection.Database
-            .Table<CategoryModel>()
-            .Where(c => c.Id == categoryToCreate.Id)
-            .FirstAsync();
+        var createdCategory = await CreateInternal(categoryToCreate);
 
         return _mapper.MapToDomain(createdCategory);
+    }
+
+    internal async Task<CategoryModel> CreateInternal(CategoryModel category)
+    {
+        await _dbConnection.Init();
+        await _dbConnection.Database.InsertAsync(category);
+
+        return await _dbConnection.Database
+            .Table<CategoryModel>()
+            .Where(c => c.Id == category.Id)
+            .FirstAsync();
     }
 
     public async Task<Category> Update(Category category)

--- a/src/Profitocracy.Infrastructure/Persistence/Sqlite/Repositories/CategoryRepository.cs
+++ b/src/Profitocracy.Infrastructure/Persistence/Sqlite/Repositories/CategoryRepository.cs
@@ -21,13 +21,7 @@ internal class CategoryRepository : ICategoryRepository
 
     public async Task<List<Category>> GetAllByProfileId(Guid profileId)
     {
-        await _dbConnection.Init();
-
-        var categories = await _dbConnection.Database
-            .Table<CategoryModel>()
-            .Where(c => c.ProfileId.Equals(profileId))
-            .OrderByDescending(c => c.PlannedAmount)
-            .ToListAsync();
+        var categories = await GetAllByProfileIdInternal(profileId);
 
         var domainCategories = categories
             .Select(_mapper.MapToDomain)
@@ -38,11 +32,7 @@ internal class CategoryRepository : ICategoryRepository
 
     public async Task<Category?> GetById(Guid categoryId)
     {
-        await _dbConnection.Init();
-
-        var category = await _dbConnection.Database
-            .Table<CategoryModel>()
-            .FirstOrDefaultAsync(c => c.Id == categoryId);
+        var category = await GetByIdInternal(categoryId);
 
         return category is not null
             ? _mapper.MapToDomain(category)
@@ -97,5 +87,27 @@ internal class CategoryRepository : ICategoryRepository
         await _dbConnection.Database
             .Table<CategoryModel>()
             .DeleteAsync(c => c.ProfileId == profileId);
+    }
+
+    public async Task<List<CategoryModel>> GetAllByProfileIdInternal(Guid profileId)
+    {
+        await _dbConnection.Init();
+
+        var categories = await _dbConnection.Database
+            .Table<CategoryModel>()
+            .Where(c => c.ProfileId.Equals(profileId))
+            .OrderByDescending(c => c.PlannedAmount)
+            .ToListAsync();
+
+        return categories ?? [];
+    }
+
+    public async Task<CategoryModel?> GetByIdInternal(Guid categoryId)
+    {
+        await _dbConnection.Init();
+
+        return await _dbConnection.Database
+            .Table<CategoryModel>()
+            .FirstOrDefaultAsync(c => c.Id == categoryId);
     }
 }

--- a/src/Profitocracy.Infrastructure/Persistence/Sqlite/Repositories/ProfileRepository.cs
+++ b/src/Profitocracy.Infrastructure/Persistence/Sqlite/Repositories/ProfileRepository.cs
@@ -21,17 +21,21 @@ internal class ProfileRepository : IProfileRepository
 
     public async Task<Profile> Create(Profile profile)
     {
-        await _dbConnection.Init();
-
         var profileToCreate = _mapper.MapToModel(profile);
-        _ = await _dbConnection.Database.InsertAsync(profileToCreate);
+        var createdProfile = await CreateInternal(profileToCreate);
 
-        var createdProfile = await _dbConnection.Database
+        return _mapper.MapToDomain(createdProfile);
+    }
+
+    internal async Task<ProfileModel> CreateInternal(ProfileModel profile)
+    {
+        await _dbConnection.Init();
+        await _dbConnection.Database.InsertAsync(profile);
+
+        return await _dbConnection.Database
             .Table<ProfileModel>()
             .Where(p => p.Id.Equals(profile.Id))
             .FirstAsync();
-
-        return _mapper.MapToDomain(createdProfile);
     }
 
     public async Task<Profile> Update(Profile profile)
@@ -99,7 +103,7 @@ internal class ProfileRepository : IProfileRepository
             : _mapper.MapToDomain(profile);
     }
 
-    public async Task<List<ProfileModel>> GetAllProfilesInternal()
+    internal async Task<List<ProfileModel>> GetAllProfilesInternal()
     {
         await _dbConnection.Init();
 
@@ -110,7 +114,7 @@ internal class ProfileRepository : IProfileRepository
         return profiles ?? [];
     }
 
-    public async Task<ProfileModel?> GetProfileByIdInternal(Guid id)
+    internal async Task<ProfileModel?> GetProfileByIdInternal(Guid id)
     {
         await _dbConnection.Init();
 
@@ -120,7 +124,7 @@ internal class ProfileRepository : IProfileRepository
             .FirstOrDefaultAsync();
     }
 
-    public async Task<ProfileModel?> GetCurrentProfileInternal()
+    internal async Task<ProfileModel?> GetCurrentProfileInternal()
     {
         await _dbConnection.Init();
 

--- a/src/Profitocracy.Infrastructure/Persistence/Sqlite/Repositories/ProfileRepository.cs
+++ b/src/Profitocracy.Infrastructure/Persistence/Sqlite/Repositories/ProfileRepository.cs
@@ -74,11 +74,7 @@ internal class ProfileRepository : IProfileRepository
 
     public async Task<List<Profile>> GetAllProfiles()
     {
-        await _dbConnection.Init();
-
-        var profiles = await _dbConnection.Database
-            .Table<ProfileModel>()
-            .ToListAsync();
+        var profiles = await GetAllProfilesInternal();
 
         return profiles
             .Select(_mapper.MapToDomain)
@@ -87,12 +83,7 @@ internal class ProfileRepository : IProfileRepository
 
     public async Task<Profile?> GetProfileById(Guid id)
     {
-        await _dbConnection.Init();
-
-        var profile = await _dbConnection.Database
-            .Table<ProfileModel>()
-            .Where(p => p.Id == id)
-            .FirstOrDefaultAsync();
+        var profile = await GetProfileByIdInternal(id);
 
         return profile is null
             ? null
@@ -101,15 +92,41 @@ internal class ProfileRepository : IProfileRepository
 
     public async Task<Profile?> GetCurrentProfile()
     {
-        await _dbConnection.Init();
-
-        var profile = await _dbConnection.Database
-            .Table<ProfileModel>()
-            .Where(p => p.IsCurrent)
-            .FirstOrDefaultAsync();
+        var profile = await GetCurrentProfileInternal();
 
         return profile is null
             ? null
             : _mapper.MapToDomain(profile);
+    }
+
+    public async Task<List<ProfileModel>> GetAllProfilesInternal()
+    {
+        await _dbConnection.Init();
+
+        var profiles = await _dbConnection.Database
+            .Table<ProfileModel>()
+            .ToListAsync();
+
+        return profiles ?? [];
+    }
+
+    public async Task<ProfileModel?> GetProfileByIdInternal(Guid id)
+    {
+        await _dbConnection.Init();
+
+        return await _dbConnection.Database
+            .Table<ProfileModel>()
+            .Where(p => p.Id == id)
+            .FirstOrDefaultAsync();
+    }
+
+    public async Task<ProfileModel?> GetCurrentProfileInternal()
+    {
+        await _dbConnection.Init();
+
+        return await _dbConnection.Database
+            .Table<ProfileModel>()
+            .Where(p => p.IsCurrent)
+            .FirstOrDefaultAsync();
     }
 }

--- a/src/Profitocracy.Infrastructure/Persistence/Sqlite/Repositories/TransactionRepository.cs
+++ b/src/Profitocracy.Infrastructure/Persistence/Sqlite/Repositories/TransactionRepository.cs
@@ -60,17 +60,21 @@ internal class TransactionRepository : ITransactionRepository
 
     public async Task<Transaction> Create(Transaction transaction)
     {
-        await _dbConnection.Init();
-
         var transactionToCreate = _mapper.MapToModel(transaction);
-        await _dbConnection.Database.InsertAsync(transactionToCreate);
+        var createdTransaction = await CreateInternal(transactionToCreate);
 
-        var createdTransaction = await _dbConnection.Database
+        return _mapper.MapToDomain(createdTransaction);
+    }
+
+    internal async Task<TransactionModel> CreateInternal(TransactionModel transaction)
+    {
+        await _dbConnection.Init();
+        await _dbConnection.Database.InsertAsync(transaction);
+
+        return await _dbConnection.Database
             .Table<TransactionModel>()
             .Where(t => t.Id.Equals(transaction.Id))
             .FirstOrDefaultAsync();
-
-        return _mapper.MapToDomain(createdTransaction);
     }
 
     public async Task<Transaction> Update(Transaction transaction)
@@ -147,7 +151,7 @@ internal class TransactionRepository : ITransactionRepository
             .DeleteAsync(t => t.ProfileId == profileId);
     }
 
-    public async Task<List<TransactionModel>> GetAllByProfileIdInternal(Guid profileId)
+    internal async Task<List<TransactionModel>> GetAllByProfileIdInternal(Guid profileId)
     {
         await _dbConnection.Init();
 
@@ -160,7 +164,7 @@ internal class TransactionRepository : ITransactionRepository
         return transactions ?? [];
     }
 
-    public async Task<TransactionModel?> GetByIdInternal(Guid transactionId)
+    internal async Task<TransactionModel?> GetByIdInternal(Guid transactionId)
     {
         await _dbConnection.Init();
 
@@ -170,7 +174,7 @@ internal class TransactionRepository : ITransactionRepository
             .FirstOrDefaultAsync();
     }
 
-    public async Task<List<TransactionModel>> GetForPeriodInternal(Guid profileId, DateTime dateFrom, DateTime dateTo)
+    internal async Task<List<TransactionModel>> GetForPeriodInternal(Guid profileId, DateTime dateFrom, DateTime dateTo)
     {
         await _dbConnection.Init();
 
@@ -184,7 +188,7 @@ internal class TransactionRepository : ITransactionRepository
         return transactions ?? [];
     }
 
-    public async Task<List<TransactionModel>> GetFilteredInternal(TransactionsSpecification spec)
+    internal async Task<List<TransactionModel>> GetFilteredInternal(TransactionsSpecification spec)
     {
         await _dbConnection.Init();
 

--- a/src/Profitocracy.Infrastructure/Profitocracy.Infrastructure.csproj
+++ b/src/Profitocracy.Infrastructure/Profitocracy.Infrastructure.csproj
@@ -12,7 +12,7 @@
     
     <ItemGroup>
       <PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
-      <PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.10" />
+      <PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.11" />
     </ItemGroup>
 
 </Project>

--- a/src/Profitocracy.Mobile/MauiProgram.cs
+++ b/src/Profitocracy.Mobile/MauiProgram.cs
@@ -1,4 +1,5 @@
-﻿using LiveChartsCore.SkiaSharpView.Maui;
+﻿using CommunityToolkit.Maui;
+using LiveChartsCore.SkiaSharpView.Maui;
 using Microsoft.Extensions.Logging;
 using Plugin.Maui.AppRating;
 using Plugin.Maui.Biometric;
@@ -26,10 +27,12 @@ public static class MauiProgram
     {
         var builder = MauiApp.CreateBuilder();
 
+#pragma warning disable CA1416 // This call site is reachable on ....
         builder
             .UseSkiaSharp()
             .UseLiveCharts()
             .UseMauiApp<App>()
+            .UseMauiCommunityToolkit()
             .ConfigureFonts(fonts =>
             {
                 fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
@@ -39,7 +42,7 @@ public static class MauiProgram
             .RegisterAppServices()
             .RegisterViewModels()
             .RegisterViews();
-
+#pragma warning restore CA1416
 
 #if DEBUG
         builder.Logging.AddDebug();

--- a/src/Profitocracy.Mobile/MauiProgram.cs
+++ b/src/Profitocracy.Mobile/MauiProgram.cs
@@ -84,6 +84,7 @@ public static class MauiProgram
             .AddTransient<LanguageSettingsViewModel>()
             .AddTransient<ProfileSettingsPageViewModel>()
             .AddTransient<TransactionsFiltersPageViewModel>()
+            .AddTransient<ImportExportSettingsPageViewModel>()
             .AddTransient<EditProfilePageViewModel>()
             .AddTransient<ThemeSettingsPageViewModel>()
             .AddTransient<AuthSettingsPageViewModel>();
@@ -106,6 +107,7 @@ public static class MauiProgram
             .AddTransient<ProfilesSettingsPage>()
             .AddTransient<EditProfilePage>()
             .AddTransient<ThemeSettingsPage>()
+            .AddTransient<ImportExportSettingsPage>()
             .AddTransient<LanguageSettingsPage>()
             .AddTransient<AuthSettingsPage>();
 

--- a/src/Profitocracy.Mobile/Platforms/Android/AndroidManifest.xml
+++ b/src/Profitocracy.Mobile/Platforms/Android/AndroidManifest.xml
@@ -4,4 +4,7 @@
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.USE_BIOMETRIC" />
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
 </manifest>

--- a/src/Profitocracy.Mobile/Platforms/Android/AndroidManifest.xml
+++ b/src/Profitocracy.Mobile/Platforms/Android/AndroidManifest.xml
@@ -4,7 +4,6 @@
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.USE_BIOMETRIC" />
-  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
 </manifest>

--- a/src/Profitocracy.Mobile/Platforms/iOS/Info.plist
+++ b/src/Profitocracy.Mobile/Platforms/iOS/Info.plist
@@ -32,5 +32,7 @@
 	<string>Assets.xcassets/appicon.appiconset</string>
   <key>NSFaceIDUsageDescription</key>
   <string>Need access to the FaceID.</string>
+  <key>com.apple.security.files.user-selected.read-only</key>
+  <true/>
 </dict>
 </plist>

--- a/src/Profitocracy.Mobile/Profitocracy.Mobile.csproj
+++ b/src/Profitocracy.Mobile/Profitocracy.Mobile.csproj
@@ -29,15 +29,16 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="CommunityToolkit.Maui" Version="12.1.0" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
         <PackageReference Include="LiveChartsCore.SkiaSharpView.Maui" Version="2.0.0-rc5.4" />
-        <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.40" />
-        <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.40" />
+        <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.90" />
+        <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.90" />
         <PackageReference Include="Plugin.Maui.AppRating" Version="1.2.1" />
         <PackageReference Include="Plugin.Maui.Biometric" Version="0.0.7" />
 
         <!-- Development dependencies -->
-        <PackageReference Condition="'$(Configuration)' != 'Release'" Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
+        <PackageReference Condition="'$(Configuration)' != 'Release'" Include="Microsoft.Extensions.Logging.Debug" Version="9.0.7" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.Designer.cs
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.Designer.cs
@@ -1478,5 +1478,29 @@ namespace Profitocracy.Mobile.Resources.Strings {
                 return ResourceManager.GetString("Settings_RateTheApp", resourceCulture);
             }
         }
+        
+        internal static string Settings_ImportExport {
+            get {
+                return ResourceManager.GetString("Settings_ImportExport", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_Import {
+            get {
+                return ResourceManager.GetString("ImportExport_Import", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_Export {
+            get {
+                return ResourceManager.GetString("ImportExport_Export", resourceCulture);
+            }
+        }
+        
+        internal static string Pages_ImportExport {
+            get {
+                return ResourceManager.GetString("Pages_ImportExport", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.Designer.cs
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.Designer.cs
@@ -1556,5 +1556,53 @@ namespace Profitocracy.Mobile.Resources.Strings {
                 return ResourceManager.GetString("ImportExport_SelectBackupFile", resourceCulture);
             }
         }
+        
+        internal static string AuthSettings_General {
+            get {
+                return ResourceManager.GetString("AuthSettings_General", resourceCulture);
+            }
+        }
+        
+        internal static string AuthSettings_Authentication {
+            get {
+                return ResourceManager.GetString("AuthSettings_Authentication", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessImportAlert_Description {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessImportAlert_Description", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessExportAlert_Description {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessExportAlert_Description", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessExportAlert_Title {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessExportAlert_Title", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessExportAlert_Ok {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessExportAlert_Ok", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessImportAlert_Ok {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessImportAlert_Ok", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessImportAlert_Title {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessImportAlert_Title", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.Designer.cs
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.Designer.cs
@@ -1502,5 +1502,59 @@ namespace Profitocracy.Mobile.Resources.Strings {
                 return ResourceManager.GetString("Pages_ImportExport", resourceCulture);
             }
         }
+        
+        internal static string ImportExport_ExportProfiles {
+            get {
+                return ResourceManager.GetString("ImportExport_ExportProfiles", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ExportCategories {
+            get {
+                return ResourceManager.GetString("ImportExport_ExportCategories", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ExportTransactions {
+            get {
+                return ResourceManager.GetString("ImportExport_ExportTransactions", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ChooseFile {
+            get {
+                return ResourceManager.GetString("ImportExport_ChooseFile", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ExportFile {
+            get {
+                return ResourceManager.GetString("ImportExport_ExportFile", resourceCulture);
+            }
+        }
+        
+        internal static string CommonError_ExportDataIsEmpty {
+            get {
+                return ResourceManager.GetString("CommonError_ExportDataIsEmpty", resourceCulture);
+            }
+        }
+        
+        internal static string CommonError_NoDataToImport {
+            get {
+                return ResourceManager.GetString("CommonError_NoDataToImport", resourceCulture);
+            }
+        }
+        
+        internal static string CommonError_WrongFileExtension {
+            get {
+                return ResourceManager.GetString("CommonError_WrongFileExtension", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SelectBackupFile {
+            get {
+                return ResourceManager.GetString("ImportExport_SelectBackupFile", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.de.resx
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.de.resx
@@ -834,4 +834,67 @@
   <data name="Settings_RateTheApp" xml:space="preserve">
       <value>Bewerten Sie die App</value>
   </data>
+  <data name="AuthSettings_General" xml:space="preserve">
+      <value>Allgemein</value>
+  </data>
+  <data name="AuthSettings_Authentication" xml:space="preserve">
+      <value>Authentifizierung</value>
+  </data>
+  <data name="CommonError_ExportDataIsEmpty" xml:space="preserve">
+      <value>Es gibt keine Daten zu exportieren</value>
+  </data>
+  <data name="CommonError_NoDataToImport" xml:space="preserve">
+      <value>Es gibt keine Daten zu importieren</value>
+  </data>
+  <data name="CommonError_WrongFileExtension" xml:space="preserve">
+      <value>Nicht unterstützter Dateityp</value>
+  </data>
+  <data name="ImportExport_ChooseFile" xml:space="preserve">
+      <value>Wählen Sie eine Datei</value>
+  </data>
+  <data name="ImportExport_Export" xml:space="preserve">
+      <value>Exportieren</value>
+  </data>
+  <data name="ImportExport_ExportCategories" xml:space="preserve">
+      <value>Kategorien exportieren</value>
+  </data>
+  <data name="ImportExport_ExportFile" xml:space="preserve">
+      <value>In eine Datei exportieren</value>
+  </data>
+  <data name="ImportExport_ExportProfiles" xml:space="preserve">
+      <value>Profile exportieren</value>
+  </data>
+  <data name="ImportExport_ExportTransactions" xml:space="preserve">
+      <value>Transaktionen exportieren</value>
+  </data>
+  <data name="ImportExport_Import" xml:space="preserve">
+      <value>Importieren</value>
+  </data>
+  <data name="ImportExport_SelectBackupFile" xml:space="preserve">
+      <value>Wählen Sie eine Profitocracy-Sicherungsdatei</value>
+  </data>
+  <data name="ImportExport_SuccessExportAlert_Description" xml:space="preserve">
+      <value>Daten wurden erfolgreich exportiert</value>
+  </data>
+  <data name="ImportExport_SuccessImportAlert_Description" xml:space="preserve">
+      <value>Daten wurden erfolgreich importiert</value>
+  </data>
+  <data name="ImportExport_SuccessExportAlert_Title" xml:space="preserve">
+      <value>Erfolg</value>
+  </data>
+  <data name="ImportExport_SuccessImportAlert_Title" xml:space="preserve">
+      <value>Erfolg</value>
+  </data>
+  <data name="ImportExport_SuccessExportAlert_Ok" xml:space="preserve">
+      <value>OK</value>
+  </data>
+  <data name="ImportExport_SuccessImportAlert_Ok" xml:space="preserve">
+      <value>OK</value>
+  </data>
+  <data name="Pages_ImportExport" xml:space="preserve">
+      <value>Import/Export</value>
+  </data>
+  <data name="Settings_ImportExport" xml:space="preserve">
+      <value>Import/Export</value>
+  </data>
 </root>

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.es.Designer.cs
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.es.Designer.cs
@@ -1478,5 +1478,131 @@ namespace Profitocracy.Mobile.Resources.Strings {
                 return ResourceManager.GetString("Settings_RateTheApp", resourceCulture);
             }
         }
+        
+        internal static string AuthSettings_General {
+            get {
+                return ResourceManager.GetString("AuthSettings_General", resourceCulture);
+            }
+        }
+        
+        internal static string AuthSettings_Authentication {
+            get {
+                return ResourceManager.GetString("AuthSettings_Authentication", resourceCulture);
+            }
+        }
+        
+        internal static string CommonError_ExportDataIsEmpty {
+            get {
+                return ResourceManager.GetString("CommonError_ExportDataIsEmpty", resourceCulture);
+            }
+        }
+        
+        internal static string CommonError_NoDataToImport {
+            get {
+                return ResourceManager.GetString("CommonError_NoDataToImport", resourceCulture);
+            }
+        }
+        
+        internal static string CommonError_WrongFileExtension {
+            get {
+                return ResourceManager.GetString("CommonError_WrongFileExtension", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ChooseFile {
+            get {
+                return ResourceManager.GetString("ImportExport_ChooseFile", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_Export {
+            get {
+                return ResourceManager.GetString("ImportExport_Export", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ExportCategories {
+            get {
+                return ResourceManager.GetString("ImportExport_ExportCategories", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ExportFile {
+            get {
+                return ResourceManager.GetString("ImportExport_ExportFile", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ExportProfiles {
+            get {
+                return ResourceManager.GetString("ImportExport_ExportProfiles", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ExportTransactions {
+            get {
+                return ResourceManager.GetString("ImportExport_ExportTransactions", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_Import {
+            get {
+                return ResourceManager.GetString("ImportExport_Import", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SelectBackupFile {
+            get {
+                return ResourceManager.GetString("ImportExport_SelectBackupFile", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessExportAlert_Description {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessExportAlert_Description", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessImportAlert_Description {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessImportAlert_Description", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessImportAlert_Title {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessImportAlert_Title", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessExportAlert_Title {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessExportAlert_Title", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessExportAlert_Ok {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessExportAlert_Ok", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessImportAlert_Ok {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessImportAlert_Ok", resourceCulture);
+            }
+        }
+        
+        internal static string Pages_ImportExport {
+            get {
+                return ResourceManager.GetString("Pages_ImportExport", resourceCulture);
+            }
+        }
+        
+        internal static string Settings_ImportExport {
+            get {
+                return ResourceManager.GetString("Settings_ImportExport", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.es.resx
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.es.resx
@@ -834,4 +834,67 @@
   <data name="Settings_RateTheApp" xml:space="preserve">
       <value>Califica la aplicación</value>
   </data>
+  <data name="AuthSettings_General" xml:space="preserve">
+      <value>General</value>
+  </data>
+  <data name="AuthSettings_Authentication" xml:space="preserve">
+      <value>Autenticación</value>
+  </data>
+  <data name="CommonError_ExportDataIsEmpty" xml:space="preserve">
+      <value>No hay datos para exportar</value>
+  </data>
+  <data name="CommonError_NoDataToImport" xml:space="preserve">
+      <value>No hay datos para importar</value>
+  </data>
+  <data name="CommonError_WrongFileExtension" xml:space="preserve">
+      <value>Tipo de archivo no compatible</value>
+  </data>
+  <data name="ImportExport_ChooseFile" xml:space="preserve">
+      <value>Seleccione un archivo</value>
+  </data>
+  <data name="ImportExport_Export" xml:space="preserve">
+      <value>Exportar</value>
+  </data>
+  <data name="ImportExport_ExportCategories" xml:space="preserve">
+      <value>Exportar categorías</value>
+  </data>
+  <data name="ImportExport_ExportFile" xml:space="preserve">
+      <value>Exportar a un archivo</value>
+  </data>
+  <data name="ImportExport_ExportProfiles" xml:space="preserve">
+      <value>Exportar perfiles</value>
+  </data>
+  <data name="ImportExport_ExportTransactions" xml:space="preserve">
+      <value>Exportar transacciones</value>
+  </data>
+  <data name="ImportExport_Import" xml:space="preserve">
+      <value>Importar</value>
+  </data>
+  <data name="ImportExport_SelectBackupFile" xml:space="preserve">
+      <value>Seleccione un archivo de copia de seguridad de Profitocracy</value>
+  </data>
+  <data name="ImportExport_SuccessExportAlert_Description" xml:space="preserve">
+      <value>Los datos se exportaron correctamente</value>
+  </data>
+  <data name="ImportExport_SuccessImportAlert_Description" xml:space="preserve">
+      <value>Los datos se importaron correctamente</value>
+  </data>
+  <data name="ImportExport_SuccessImportAlert_Title" xml:space="preserve">
+      <value>Éxito</value>
+  </data>
+  <data name="ImportExport_SuccessExportAlert_Title" xml:space="preserve">
+      <value>Éxito</value>
+  </data>
+  <data name="ImportExport_SuccessExportAlert_Ok" xml:space="preserve">
+      <value>OK</value>
+  </data>
+  <data name="ImportExport_SuccessImportAlert_Ok" xml:space="preserve">
+      <value>OK</value>
+  </data>
+  <data name="Pages_ImportExport" xml:space="preserve">
+      <value>Importar/Exportar</value>
+  </data>
+  <data name="Settings_ImportExport" xml:space="preserve">
+      <value>Importar/Exportar</value>
+  </data>
 </root>

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.fr.Designer.cs
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.fr.Designer.cs
@@ -1478,5 +1478,131 @@ namespace Profitocracy.Mobile.Resources.Strings {
                 return ResourceManager.GetString("Settings_RateTheApp", resourceCulture);
             }
         }
+        
+        internal static string AuthSettings_General {
+            get {
+                return ResourceManager.GetString("AuthSettings_General", resourceCulture);
+            }
+        }
+        
+        internal static string AuthSettings_Authentication {
+            get {
+                return ResourceManager.GetString("AuthSettings_Authentication", resourceCulture);
+            }
+        }
+        
+        internal static string CommonError_ExportDataIsEmpty {
+            get {
+                return ResourceManager.GetString("CommonError_ExportDataIsEmpty", resourceCulture);
+            }
+        }
+        
+        internal static string CommonError_NoDataToImport {
+            get {
+                return ResourceManager.GetString("CommonError_NoDataToImport", resourceCulture);
+            }
+        }
+        
+        internal static string CommonError_WrongFileExtension {
+            get {
+                return ResourceManager.GetString("CommonError_WrongFileExtension", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ChooseFile {
+            get {
+                return ResourceManager.GetString("ImportExport_ChooseFile", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_Export {
+            get {
+                return ResourceManager.GetString("ImportExport_Export", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ExportCategories {
+            get {
+                return ResourceManager.GetString("ImportExport_ExportCategories", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ExportFile {
+            get {
+                return ResourceManager.GetString("ImportExport_ExportFile", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ExportProfiles {
+            get {
+                return ResourceManager.GetString("ImportExport_ExportProfiles", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ExportTransactions {
+            get {
+                return ResourceManager.GetString("ImportExport_ExportTransactions", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_Import {
+            get {
+                return ResourceManager.GetString("ImportExport_Import", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SelectBackupFile {
+            get {
+                return ResourceManager.GetString("ImportExport_SelectBackupFile", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessExportAlert_Description {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessExportAlert_Description", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessImportAlert_Description {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessImportAlert_Description", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessExportAlert_Title {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessExportAlert_Title", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessImportAlert_Title {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessImportAlert_Title", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessExportAlert_Ok {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessExportAlert_Ok", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessImportAlert_Ok {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessImportAlert_Ok", resourceCulture);
+            }
+        }
+        
+        internal static string Pages_ImportExport {
+            get {
+                return ResourceManager.GetString("Pages_ImportExport", resourceCulture);
+            }
+        }
+        
+        internal static string Settings_ImportExport {
+            get {
+                return ResourceManager.GetString("Settings_ImportExport", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.fr.resx
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.fr.resx
@@ -834,4 +834,67 @@
   <data name="Settings_RateTheApp" xml:space="preserve">
       <value>Notez l'application</value>
   </data>
+  <data name="AuthSettings_General" xml:space="preserve">
+      <value>Général</value>
+  </data>
+  <data name="AuthSettings_Authentication" xml:space="preserve">
+      <value>Authentification</value>
+  </data>
+  <data name="CommonError_ExportDataIsEmpty" xml:space="preserve">
+      <value>Il n'y a pas de données à exporter</value>
+  </data>
+  <data name="CommonError_NoDataToImport" xml:space="preserve">
+      <value>Il n'y a pas de données à importer</value>
+  </data>
+  <data name="CommonError_WrongFileExtension" xml:space="preserve">
+      <value>Type de fichier non pris en charge</value>
+  </data>
+  <data name="ImportExport_ChooseFile" xml:space="preserve">
+      <value>Sélectionnez un fichier</value>
+  </data>
+  <data name="ImportExport_Export" xml:space="preserve">
+      <value>Exporter</value>
+  </data>
+  <data name="ImportExport_ExportCategories" xml:space="preserve">
+      <value>Exporter des catégories</value>
+  </data>
+  <data name="ImportExport_ExportFile" xml:space="preserve">
+      <value>Exporter vers un fichier</value>
+  </data>
+  <data name="ImportExport_ExportProfiles" xml:space="preserve">
+      <value>Exporter des profils</value>
+  </data>
+  <data name="ImportExport_ExportTransactions" xml:space="preserve">
+      <value>Exporter des transactions</value>
+  </data>
+  <data name="ImportExport_Import" xml:space="preserve">
+      <value>Importer</value>
+  </data>
+  <data name="ImportExport_SelectBackupFile" xml:space="preserve">
+      <value>Sélectionnez un fichier de sauvegarde Profitocracy</value>
+  </data>
+  <data name="ImportExport_SuccessExportAlert_Description" xml:space="preserve">
+      <value>Les données ont été exportées avec succès</value>
+  </data>
+  <data name="ImportExport_SuccessImportAlert_Description" xml:space="preserve">
+      <value>Les données ont été importées avec succès</value>
+  </data>
+  <data name="ImportExport_SuccessExportAlert_Title" xml:space="preserve">
+      <value>Succès</value>
+  </data>
+  <data name="ImportExport_SuccessImportAlert_Title" xml:space="preserve">
+      <value>Succès</value>
+  </data>
+  <data name="ImportExport_SuccessExportAlert_Ok" xml:space="preserve">
+      <value>OK</value>
+  </data>
+  <data name="ImportExport_SuccessImportAlert_Ok" xml:space="preserve">
+      <value>OK</value>
+  </data>
+  <data name="Pages_ImportExport" xml:space="preserve">
+      <value>Importer/Exporter</value>
+  </data>
+  <data name="Settings_ImportExport" xml:space="preserve">
+      <value>Importer/Exporter</value>
+  </data>
 </root>

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.resx
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.resx
@@ -835,4 +835,16 @@
   <data name="Settings_RateTheApp" xml:space="preserve">
       <value>Rate the app</value>
   </data>
+  <data name="Settings_ImportExport" xml:space="preserve">
+      <value>Import/Export</value>
+  </data>
+  <data name="ImportExport_Import" xml:space="preserve">
+      <value>Import</value>
+  </data>
+  <data name="ImportExport_Export" xml:space="preserve">
+      <value>Export</value>
+  </data>
+  <data name="Pages_ImportExport" xml:space="preserve">
+      <value>Import/Export</value>
+  </data>
 </root>

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.resx
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.resx
@@ -847,4 +847,31 @@
   <data name="Pages_ImportExport" xml:space="preserve">
       <value>Import/Export</value>
   </data>
+  <data name="ImportExport_ExportProfiles" xml:space="preserve">
+      <value>Export profiles</value>
+  </data>
+  <data name="ImportExport_ExportCategories" xml:space="preserve">
+      <value>Export categories</value>
+  </data>
+  <data name="ImportExport_ExportTransactions" xml:space="preserve">
+      <value>Export transactions</value>
+  </data>
+  <data name="ImportExport_ChooseFile" xml:space="preserve">
+      <value>Select a file</value>
+  </data>
+  <data name="ImportExport_ExportFile" xml:space="preserve">
+      <value>Export to a file</value>
+  </data>
+  <data name="CommonError_ExportDataIsEmpty" xml:space="preserve">
+      <value>There is no data to export</value>
+  </data>
+  <data name="CommonError_NoDataToImport" xml:space="preserve">
+      <value>There is no data to import</value>
+  </data>
+  <data name="CommonError_WrongFileExtension" xml:space="preserve">
+      <value>Unsupported file type</value>
+  </data>
+  <data name="ImportExport_SelectBackupFile" xml:space="preserve">
+      <value>Select a Profitocracy backup file</value>
+  </data>
 </root>

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.resx
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.resx
@@ -874,4 +874,28 @@
   <data name="ImportExport_SelectBackupFile" xml:space="preserve">
       <value>Select a Profitocracy backup file</value>
   </data>
+  <data name="AuthSettings_General" xml:space="preserve">
+      <value>General</value>
+  </data>
+  <data name="AuthSettings_Authentication" xml:space="preserve">
+      <value>Authentication</value>
+  </data>
+  <data name="ImportExport_SuccessImportAlert_Description" xml:space="preserve">
+      <value>Data was successfully imported</value>
+  </data>
+  <data name="ImportExport_SuccessExportAlert_Description" xml:space="preserve">
+      <value>Data was successfully exported</value>
+  </data>
+  <data name="ImportExport_SuccessExportAlert_Title" xml:space="preserve">
+      <value>Success</value>
+  </data>
+  <data name="ImportExport_SuccessExportAlert_Ok" xml:space="preserve">
+      <value>OK</value>
+  </data>
+  <data name="ImportExport_SuccessImportAlert_Ok" xml:space="preserve">
+      <value>OK</value>
+  </data>
+  <data name="ImportExport_SuccessImportAlert_Title" xml:space="preserve">
+      <value>Success</value>
+  </data>
 </root>

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.ru.Designer.cs
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.ru.Designer.cs
@@ -1478,5 +1478,131 @@ namespace Profitocracy.Mobile.Resources.Strings {
                 return ResourceManager.GetString("Settings_RateTheApp", resourceCulture);
             }
         }
+        
+        internal static string AuthSettings_General {
+            get {
+                return ResourceManager.GetString("AuthSettings_General", resourceCulture);
+            }
+        }
+        
+        internal static string AuthSettings_Authentication {
+            get {
+                return ResourceManager.GetString("AuthSettings_Authentication", resourceCulture);
+            }
+        }
+        
+        internal static string CommonError_ExportDataIsEmpty {
+            get {
+                return ResourceManager.GetString("CommonError_ExportDataIsEmpty", resourceCulture);
+            }
+        }
+        
+        internal static string CommonError_NoDataToImport {
+            get {
+                return ResourceManager.GetString("CommonError_NoDataToImport", resourceCulture);
+            }
+        }
+        
+        internal static string CommonError_WrongFileExtension {
+            get {
+                return ResourceManager.GetString("CommonError_WrongFileExtension", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ChooseFile {
+            get {
+                return ResourceManager.GetString("ImportExport_ChooseFile", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_Export {
+            get {
+                return ResourceManager.GetString("ImportExport_Export", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ExportCategories {
+            get {
+                return ResourceManager.GetString("ImportExport_ExportCategories", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ExportFile {
+            get {
+                return ResourceManager.GetString("ImportExport_ExportFile", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ExportProfiles {
+            get {
+                return ResourceManager.GetString("ImportExport_ExportProfiles", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ExportTransactions {
+            get {
+                return ResourceManager.GetString("ImportExport_ExportTransactions", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_Import {
+            get {
+                return ResourceManager.GetString("ImportExport_Import", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SelectBackupFile {
+            get {
+                return ResourceManager.GetString("ImportExport_SelectBackupFile", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessExportAlert_Description {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessExportAlert_Description", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessImportAlert_Description {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessImportAlert_Description", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessExportAlert_Title {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessExportAlert_Title", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessImportAlert_Title {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessImportAlert_Title", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessExportAlert_Ok {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessExportAlert_Ok", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessImportAlert_Ok {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessImportAlert_Ok", resourceCulture);
+            }
+        }
+        
+        internal static string Settings_ImportExport {
+            get {
+                return ResourceManager.GetString("Settings_ImportExport", resourceCulture);
+            }
+        }
+        
+        internal static string Pages_ImportExport {
+            get {
+                return ResourceManager.GetString("Pages_ImportExport", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.ru.resx
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.ru.resx
@@ -834,4 +834,67 @@
   <data name="Settings_RateTheApp" xml:space="preserve">
       <value>Оцените приложение</value>
   </data>
+  <data name="AuthSettings_General" xml:space="preserve">
+      <value>Основные</value>
+  </data>
+  <data name="AuthSettings_Authentication" xml:space="preserve">
+      <value>Аутентификация</value>
+  </data>
+  <data name="CommonError_ExportDataIsEmpty" xml:space="preserve">
+      <value>Нет данных для экспорта</value>
+  </data>
+  <data name="CommonError_NoDataToImport" xml:space="preserve">
+      <value>Нет данных для импорта</value>
+  </data>
+  <data name="CommonError_WrongFileExtension" xml:space="preserve">
+      <value>Неподдерживаемый тип файла</value>
+  </data>
+  <data name="ImportExport_ChooseFile" xml:space="preserve">
+      <value>Выберите файл</value>
+  </data>
+  <data name="ImportExport_Export" xml:space="preserve">
+      <value>Экспорт</value>
+  </data>
+  <data name="ImportExport_ExportCategories" xml:space="preserve">
+      <value>Экспортировать категории</value>
+  </data>
+  <data name="ImportExport_ExportFile" xml:space="preserve">
+      <value>Экспортировать в файл</value>
+  </data>
+  <data name="ImportExport_ExportProfiles" xml:space="preserve">
+      <value>Экспортировать профили</value>
+  </data>
+  <data name="ImportExport_ExportTransactions" xml:space="preserve">
+      <value>Экспортировать транзакции</value>
+  </data>
+  <data name="ImportExport_Import" xml:space="preserve">
+      <value>Импорт</value>
+  </data>
+  <data name="ImportExport_SelectBackupFile" xml:space="preserve">
+      <value>Выберите файл резервной копии Profitocracy</value>
+  </data>
+  <data name="ImportExport_SuccessExportAlert_Description" xml:space="preserve">
+      <value>Данные успешно экспортированы</value>
+  </data>
+  <data name="ImportExport_SuccessImportAlert_Description" xml:space="preserve">
+      <value>Данные успешно импортированы</value>
+  </data>
+  <data name="ImportExport_SuccessExportAlert_Title" xml:space="preserve">
+      <value>Успех</value>
+  </data>
+  <data name="ImportExport_SuccessImportAlert_Title" xml:space="preserve">
+      <value>Успех</value>
+  </data>
+  <data name="ImportExport_SuccessExportAlert_Ok" xml:space="preserve">
+      <value>OK</value>
+  </data>
+  <data name="ImportExport_SuccessImportAlert_Ok" xml:space="preserve">
+      <value>OK</value>
+  </data>
+  <data name="Settings_ImportExport" xml:space="preserve">
+      <value>Импорт/Экспорт</value>
+  </data>
+  <data name="Pages_ImportExport" xml:space="preserve">
+      <value>Импорт/Экспорт</value>
+  </data>
 </root>

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.sr-Latn.Designer.cs
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.sr-Latn.Designer.cs
@@ -1478,5 +1478,131 @@ namespace Profitocracy.Mobile.Resources.Strings {
                 return ResourceManager.GetString("Settings_RateTheApp", resourceCulture);
             }
         }
+        
+        internal static string AuthSettings_General {
+            get {
+                return ResourceManager.GetString("AuthSettings_General", resourceCulture);
+            }
+        }
+        
+        internal static string AuthSettings_Authentication {
+            get {
+                return ResourceManager.GetString("AuthSettings_Authentication", resourceCulture);
+            }
+        }
+        
+        internal static string CommonError_ExportDataIsEmpty {
+            get {
+                return ResourceManager.GetString("CommonError_ExportDataIsEmpty", resourceCulture);
+            }
+        }
+        
+        internal static string CommonError_NoDataToImport {
+            get {
+                return ResourceManager.GetString("CommonError_NoDataToImport", resourceCulture);
+            }
+        }
+        
+        internal static string CommonError_WrongFileExtension {
+            get {
+                return ResourceManager.GetString("CommonError_WrongFileExtension", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ChooseFile {
+            get {
+                return ResourceManager.GetString("ImportExport_ChooseFile", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_Export {
+            get {
+                return ResourceManager.GetString("ImportExport_Export", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ExportCategories {
+            get {
+                return ResourceManager.GetString("ImportExport_ExportCategories", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ExportFile {
+            get {
+                return ResourceManager.GetString("ImportExport_ExportFile", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ExportProfiles {
+            get {
+                return ResourceManager.GetString("ImportExport_ExportProfiles", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ExportTransactions {
+            get {
+                return ResourceManager.GetString("ImportExport_ExportTransactions", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_Import {
+            get {
+                return ResourceManager.GetString("ImportExport_Import", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SelectBackupFile {
+            get {
+                return ResourceManager.GetString("ImportExport_SelectBackupFile", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessExportAlert_Description {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessExportAlert_Description", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessImportAlert_Description {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessImportAlert_Description", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessImportAlert_Title {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessImportAlert_Title", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessExportAlert_Title {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessExportAlert_Title", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessExportAlert_Ok {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessExportAlert_Ok", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessImportAlert_Ok {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessImportAlert_Ok", resourceCulture);
+            }
+        }
+        
+        internal static string Pages_ImportExport {
+            get {
+                return ResourceManager.GetString("Pages_ImportExport", resourceCulture);
+            }
+        }
+        
+        internal static string Settings_ImportExport {
+            get {
+                return ResourceManager.GetString("Settings_ImportExport", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.sr-Latn.resx
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.sr-Latn.resx
@@ -834,4 +834,67 @@
   <data name="Settings_RateTheApp" xml:space="preserve">
       <value>Ocenite aplikaciju</value>
   </data>
+  <data name="AuthSettings_General" xml:space="preserve">
+      <value>Opšte</value>
+  </data>
+  <data name="AuthSettings_Authentication" xml:space="preserve">
+      <value>Autentifikacija</value>
+  </data>
+  <data name="CommonError_ExportDataIsEmpty" xml:space="preserve">
+      <value>Nema podataka za izvoz</value>
+  </data>
+  <data name="CommonError_NoDataToImport" xml:space="preserve">
+      <value>Nema podataka za uvoz</value>
+  </data>
+  <data name="CommonError_WrongFileExtension" xml:space="preserve">
+      <value>Nepodržani tip datoteke</value>
+  </data>
+  <data name="ImportExport_ChooseFile" xml:space="preserve">
+      <value>Izaberite datoteku</value>
+  </data>
+  <data name="ImportExport_Export" xml:space="preserve">
+      <value>Izvoz</value>
+  </data>
+  <data name="ImportExport_ExportCategories" xml:space="preserve">
+      <value>Izvoz kategorija</value>
+  </data>
+  <data name="ImportExport_ExportFile" xml:space="preserve">
+      <value>Izvoz u datoteku</value>
+  </data>
+  <data name="ImportExport_ExportProfiles" xml:space="preserve">
+      <value>Izvoz profila</value>
+  </data>
+  <data name="ImportExport_ExportTransactions" xml:space="preserve">
+      <value>Izvoz transakcija</value>
+  </data>
+  <data name="ImportExport_Import" xml:space="preserve">
+      <value>Uvoz</value>
+  </data>
+  <data name="ImportExport_SelectBackupFile" xml:space="preserve">
+      <value>Izaberite Profitocracy rezervnu datoteku</value>
+  </data>
+  <data name="ImportExport_SuccessExportAlert_Description" xml:space="preserve">
+      <value>Podaci su uspešno izvezeni</value>
+  </data>
+  <data name="ImportExport_SuccessImportAlert_Description" xml:space="preserve">
+      <value>Podaci su uspešno uvezeni</value>
+  </data>
+  <data name="ImportExport_SuccessImportAlert_Title" xml:space="preserve">
+      <value>Uspeh</value>
+  </data>
+  <data name="ImportExport_SuccessExportAlert_Title" xml:space="preserve">
+      <value>Uspeh</value>
+  </data>
+  <data name="ImportExport_SuccessExportAlert_Ok" xml:space="preserve">
+      <value>U redu</value>
+  </data>
+  <data name="ImportExport_SuccessImportAlert_Ok" xml:space="preserve">
+      <value>U redu</value>
+  </data>
+  <data name="Pages_ImportExport" xml:space="preserve">
+      <value>Uvoz/Izvoz</value>
+  </data>
+  <data name="Settings_ImportExport" xml:space="preserve">
+      <value>Uvoz/Izvoz</value>
+  </data>
 </root>

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.sr.Designer.cs
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.sr.Designer.cs
@@ -1478,5 +1478,131 @@ namespace Profitocracy.Mobile.Resources.Strings {
                 return ResourceManager.GetString("Settings_RateTheApp", resourceCulture);
             }
         }
+        
+        internal static string AuthSettings_General {
+            get {
+                return ResourceManager.GetString("AuthSettings_General", resourceCulture);
+            }
+        }
+        
+        internal static string AuthSettings_Authentication {
+            get {
+                return ResourceManager.GetString("AuthSettings_Authentication", resourceCulture);
+            }
+        }
+        
+        internal static string CommonError_ExportDataIsEmpty {
+            get {
+                return ResourceManager.GetString("CommonError_ExportDataIsEmpty", resourceCulture);
+            }
+        }
+        
+        internal static string CommonError_NoDataToImport {
+            get {
+                return ResourceManager.GetString("CommonError_NoDataToImport", resourceCulture);
+            }
+        }
+        
+        internal static string CommonError_WrongFileExtension {
+            get {
+                return ResourceManager.GetString("CommonError_WrongFileExtension", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ChooseFile {
+            get {
+                return ResourceManager.GetString("ImportExport_ChooseFile", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_Export {
+            get {
+                return ResourceManager.GetString("ImportExport_Export", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ExportCategories {
+            get {
+                return ResourceManager.GetString("ImportExport_ExportCategories", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ExportFile {
+            get {
+                return ResourceManager.GetString("ImportExport_ExportFile", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ExportProfiles {
+            get {
+                return ResourceManager.GetString("ImportExport_ExportProfiles", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_ExportTransactions {
+            get {
+                return ResourceManager.GetString("ImportExport_ExportTransactions", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_Import {
+            get {
+                return ResourceManager.GetString("ImportExport_Import", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SelectBackupFile {
+            get {
+                return ResourceManager.GetString("ImportExport_SelectBackupFile", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessExportAlert_Description {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessExportAlert_Description", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessImportAlert_Description {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessImportAlert_Description", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessExportAlert_Title {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessExportAlert_Title", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessImportAlert_Title {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessImportAlert_Title", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessExportAlert_Ok {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessExportAlert_Ok", resourceCulture);
+            }
+        }
+        
+        internal static string ImportExport_SuccessImportAlert_Ok {
+            get {
+                return ResourceManager.GetString("ImportExport_SuccessImportAlert_Ok", resourceCulture);
+            }
+        }
+        
+        internal static string Pages_ImportExport {
+            get {
+                return ResourceManager.GetString("Pages_ImportExport", resourceCulture);
+            }
+        }
+        
+        internal static string Settings_ImportExport {
+            get {
+                return ResourceManager.GetString("Settings_ImportExport", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.sr.resx
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.sr.resx
@@ -834,4 +834,67 @@
   <data name="Settings_RateTheApp" xml:space="preserve">
       <value>Оцените апликацију</value>
   </data>
+  <data name="AuthSettings_General" xml:space="preserve">
+      <value>Опште</value>
+  </data>
+  <data name="AuthSettings_Authentication" xml:space="preserve">
+      <value>Аутентификација</value>
+  </data>
+  <data name="CommonError_ExportDataIsEmpty" xml:space="preserve">
+      <value>Нема података за извоз</value>
+  </data>
+  <data name="CommonError_NoDataToImport" xml:space="preserve">
+      <value>Нема података за увоз</value>
+  </data>
+  <data name="CommonError_WrongFileExtension" xml:space="preserve">
+      <value>Неподржани тип датотеке</value>
+  </data>
+  <data name="ImportExport_ChooseFile" xml:space="preserve">
+      <value>Изаберите датотеку</value>
+  </data>
+  <data name="ImportExport_Export" xml:space="preserve">
+      <value>Извоз</value>
+  </data>
+  <data name="ImportExport_ExportCategories" xml:space="preserve">
+      <value>Извоз категорија</value>
+  </data>
+  <data name="ImportExport_ExportFile" xml:space="preserve">
+      <value>Извоз у датотеку</value>
+  </data>
+  <data name="ImportExport_ExportProfiles" xml:space="preserve">
+      <value>Извоз профила</value>
+  </data>
+  <data name="ImportExport_ExportTransactions" xml:space="preserve">
+      <value>Извоз трансакција</value>
+  </data>
+  <data name="ImportExport_Import" xml:space="preserve">
+      <value>Увоз</value>
+  </data>
+  <data name="ImportExport_SelectBackupFile" xml:space="preserve">
+      <value>Изаберите Profitocracy резервну датотеку</value>
+  </data>
+  <data name="ImportExport_SuccessExportAlert_Description" xml:space="preserve">
+      <value>Подаци су успешно извезени</value>
+  </data>
+  <data name="ImportExport_SuccessImportAlert_Description" xml:space="preserve">
+      <value>Подаци су успешно увезени</value>
+  </data>
+  <data name="ImportExport_SuccessExportAlert_Title" xml:space="preserve">
+      <value>Успех</value>
+  </data>
+  <data name="ImportExport_SuccessImportAlert_Title" xml:space="preserve">
+      <value>Успех</value>
+  </data>
+  <data name="ImportExport_SuccessExportAlert_Ok" xml:space="preserve">
+      <value>У реду</value>
+  </data>
+  <data name="ImportExport_SuccessImportAlert_Ok" xml:space="preserve">
+      <value>У реду</value>
+  </data>
+  <data name="Pages_ImportExport" xml:space="preserve">
+      <value>Увоз/Извоз</value>
+  </data>
+  <data name="Settings_ImportExport" xml:space="preserve">
+      <value>Увоз/Извоз</value>
+  </data>
 </root>

--- a/src/Profitocracy.Mobile/ViewModels/Settings/ImportExportSettingsPageViewModel.cs
+++ b/src/Profitocracy.Mobile/ViewModels/Settings/ImportExportSettingsPageViewModel.cs
@@ -1,8 +1,131 @@
+using CommunityToolkit.Maui.Storage;
+using Profitocracy.Core.Integrations;
 using Profitocracy.Mobile.Abstractions;
+using Profitocracy.Mobile.Resources.Strings;
 
 namespace Profitocracy.Mobile.ViewModels.Settings;
 
 public class ImportExportSettingsPageViewModel : BaseNotifyObject
 {
+    private const string BackupFileName = "profitocracy_backup";
+    private readonly IBackupProvider _backupProvider;
 
+    private bool _isExportingProfiles;
+    private bool _isExportingCategories;
+    private bool _isExportingTransactions;
+
+    public ImportExportSettingsPageViewModel(IBackupProvider backupProvider)
+    {
+        _backupProvider = backupProvider;
+    }
+
+    public bool IsExportingProfiles
+    {
+        get => _isExportingProfiles;
+        set
+        {
+            if (_isExportingProfiles == value)
+            {
+                return;
+            }
+
+            if (!value)
+            {
+                IsExportingCategories = false;
+                IsExportingTransactions = false;
+            }
+
+            SetProperty(ref _isExportingProfiles, value);
+        }
+    }
+    public bool IsExportingCategories
+    {
+        get => _isExportingCategories;
+        set
+        {
+            if (_isExportingCategories == value)
+            {
+                return;
+            }
+
+            if (value)
+            {
+                IsExportingProfiles = true;
+            }
+            else
+            {
+                IsExportingTransactions = false;
+            }
+
+            SetProperty(ref _isExportingCategories, value);
+        }
+    }
+
+    public bool IsExportingTransactions
+    {
+        get => _isExportingTransactions;
+        set
+        {
+            if (_isExportingTransactions == value)
+            {
+                return;
+            }
+
+            if (value)
+            {
+                IsExportingProfiles = true;
+                IsExportingCategories = true;
+            }
+
+            SetProperty(ref _isExportingTransactions, value);
+        }
+    }
+
+    public async Task ImportAsync()
+    {
+        var pickOptions = new PickOptions
+        {
+            PickerTitle = AppResources.ImportExport_SelectBackupFile,
+        };
+
+        var result = await FilePicker.Default.PickAsync(pickOptions);
+
+        if (result is null)
+        {
+            throw new Exception(AppResources.CommonError_NoDataToImport);
+        }
+
+        var correctExtension = result.FileName.EndsWith(
+            _backupProvider.BackupFileExtension,
+            StringComparison.InvariantCultureIgnoreCase);
+
+        if (!correctExtension)
+        {
+            throw new Exception(AppResources.CommonError_WrongFileExtension);
+        }
+
+        await using var backupFileStream = await result.OpenReadAsync();
+        await _backupProvider.ImportDataAsync(backupFileStream);
+    }
+
+    public async Task ExportAsync()
+    {
+        if (!IsExportingProfiles && !IsExportingCategories && !IsExportingTransactions)
+        {
+            throw new Exception(AppResources.CommonError_ExportDataIsEmpty);
+        }
+
+        await using var stream = await _backupProvider.ExportDataAsync(
+            IsExportingProfiles,
+            IsExportingCategories,
+            IsExportingTransactions);
+
+        var filename = $"{BackupFileName}.{_backupProvider.BackupFileExtension}";
+
+#pragma warning disable CA1416
+        var saveResult = await FileSaver.Default.SaveAsync(filename, stream);
+#pragma warning restore CA1416
+
+        saveResult.EnsureSuccess();
+    }
 }

--- a/src/Profitocracy.Mobile/ViewModels/Settings/ImportExportSettingsPageViewModel.cs
+++ b/src/Profitocracy.Mobile/ViewModels/Settings/ImportExportSettingsPageViewModel.cs
@@ -1,0 +1,8 @@
+using Profitocracy.Mobile.Abstractions;
+
+namespace Profitocracy.Mobile.ViewModels.Settings;
+
+public class ImportExportSettingsPageViewModel : BaseNotifyObject
+{
+
+}

--- a/src/Profitocracy.Mobile/ViewModels/Settings/ImportExportSettingsPageViewModel.cs
+++ b/src/Profitocracy.Mobile/ViewModels/Settings/ImportExportSettingsPageViewModel.cs
@@ -14,10 +14,10 @@ public class ImportExportSettingsPageViewModel : BaseNotifyObject
     private bool _isExportingProfiles;
     private bool _isExportingCategories;
     private bool _isExportingTransactions;
-    private bool _isShowImportProgress = false;
-    private int _currentImportIndex = 0;
-    private int _totalImportIndex = 0;
-    private float _importProgress = 0;
+    private bool _isShowImportProgress;
+    private int _currentImportIndex;
+    private int _totalImportIndex;
+    private float _importProgress;
 
     public ImportExportSettingsPageViewModel(IBackupProvider backupProvider)
     {
@@ -137,7 +137,7 @@ public class ImportExportSettingsPageViewModel : BaseNotifyObject
 
         try
         {
-            await MainThread.InvokeOnMainThreadAsync(() =>
+            MainThread.BeginInvokeOnMainThread(() =>
             {
                 IsShowImportProgress = true;
             });
@@ -146,13 +146,12 @@ public class ImportExportSettingsPageViewModel : BaseNotifyObject
 
             await foreach (var (current, total) in _backupProvider.ImportDataAsync(backupFileStream))
             {
-                await MainThread.InvokeOnMainThreadAsync(() =>
+                MainThread.BeginInvokeOnMainThread(() =>
                 {
                     CurrentImportIndex = current;
                     TotalImportIndex = total;
                     ImportProgress = total > 0 ? current / (float)total : 0;
                 });
-
             }
         }
         catch (Exception ex)
@@ -161,7 +160,7 @@ public class ImportExportSettingsPageViewModel : BaseNotifyObject
         }
         finally
         {
-            await MainThread.InvokeOnMainThreadAsync(() =>
+            MainThread.BeginInvokeOnMainThread(() =>
             {
                 IsShowImportProgress = false;
                 CurrentImportIndex = 0;

--- a/src/Profitocracy.Mobile/Views/Settings/Pages/AuthSettingsPage.xaml
+++ b/src/Profitocracy.Mobile/Views/Settings/Pages/AuthSettingsPage.xaml
@@ -26,7 +26,6 @@
                 </controls:ContentSectionView>
 
                 <controls:ContentSectionView IsVisible="{Binding IsEnabled}"
-                                             Margin="0,16,0,0"
                                              Title="">
                     <StackLayout>
                         <FlexLayout JustifyContent="SpaceBetween">

--- a/src/Profitocracy.Mobile/Views/Settings/Pages/AuthSettingsPage.xaml
+++ b/src/Profitocracy.Mobile/Views/Settings/Pages/AuthSettingsPage.xaml
@@ -17,8 +17,9 @@
                     HorizontalScrollBarVisibility="Never"
                     Grid.Row="0">
             <StackLayout>
-                <controls:ContentSectionView Title="">
-                    <FlexLayout JustifyContent="SpaceBetween">
+                <controls:ContentSectionView Title="{x:Static resx:AppResources.AuthSettings_General}">
+                    <FlexLayout JustifyContent="SpaceBetween"
+                                Margin="0,16,0,0">
                         <Label Text="{x:Static resx:AppResources.AuthSettings_Enabled}"
                                VerticalTextAlignment="Center"/>
                         <Switch IsToggled="{Binding IsEnabled, Mode=TwoWay}"/>
@@ -26,9 +27,10 @@
                 </controls:ContentSectionView>
 
                 <controls:ContentSectionView IsVisible="{Binding IsEnabled}"
-                                             Title="">
+                                             Title="{x:Static resx:AppResources.AuthSettings_Authentication}">
                     <StackLayout>
-                        <FlexLayout JustifyContent="SpaceBetween">
+                        <FlexLayout JustifyContent="SpaceBetween"
+                                    Margin="0,16,0,0">
                             <Label Text="{x:Static resx:AppResources.AuthSettings_UseBiometrics}"
                                    VerticalTextAlignment="Center"/>
                             <Switch IsToggled="{Binding IsBiometricEnabled, Mode=TwoWay}"/>

--- a/src/Profitocracy.Mobile/Views/Settings/Pages/ImportExportSettingsPage.xaml
+++ b/src/Profitocracy.Mobile/Views/Settings/Pages/ImportExportSettingsPage.xaml
@@ -14,7 +14,8 @@
         <StackLayout>
             <controls:ContentSectionView Title="{x:Static resx:AppResources.ImportExport_Import}">
                 <StackLayout>
-                    <StackLayout Margin="0,16,0,0">
+                    <StackLayout Margin="0,16,0,0"
+                                 IsVisible="{Binding IsShowImportProgress}">
                         <ProgressBar Style="{StaticResource ExpenseCardProgressBar}"
                                      Progress="{Binding ImportProgress}"/>
                         <FlexLayout JustifyContent="SpaceBetween"

--- a/src/Profitocracy.Mobile/Views/Settings/Pages/ImportExportSettingsPage.xaml
+++ b/src/Profitocracy.Mobile/Views/Settings/Pages/ImportExportSettingsPage.xaml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<abstractions:BaseContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:abstractions="clr-namespace:Profitocracy.Mobile.Abstractions"
+             xmlns:resx="clr-namespace:Profitocracy.Mobile.Resources.Strings"
+             xmlns:controls="clr-namespace:Profitocracy.Mobile.Views.Shared.Controls"
+             x:Class="Profitocracy.Mobile.Views.Settings.Pages.ImportExportSettingsPage"
+             BackgroundColor="{AppThemeBinding Light={StaticResource LightBackground}, Dark={StaticResource DarkBackground}}"
+             Title="{x:Static resx:AppResources.Pages_ImportExport}">
+    <ScrollView>
+        <StackLayout>
+            <controls:ContentSectionView Title="{x:Static resx:AppResources.ImportExport_Import}">
+                <StackLayout>
+                    <Button Margin="0,16,0,0"
+                            Text="Pick a file"/>
+                </StackLayout>
+            </controls:ContentSectionView>
+            <controls:ContentSectionView Title="{x:Static resx:AppResources.ImportExport_Export}">
+                <StackLayout>
+                    
+                </StackLayout>
+            </controls:ContentSectionView>
+        </StackLayout>
+    </ScrollView>
+</abstractions:BaseContentPage>

--- a/src/Profitocracy.Mobile/Views/Settings/Pages/ImportExportSettingsPage.xaml
+++ b/src/Profitocracy.Mobile/Views/Settings/Pages/ImportExportSettingsPage.xaml
@@ -14,6 +14,18 @@
         <StackLayout>
             <controls:ContentSectionView Title="{x:Static resx:AppResources.ImportExport_Import}">
                 <StackLayout>
+                    <StackLayout Margin="0,16,0,0">
+                        <ProgressBar Style="{StaticResource ExpenseCardProgressBar}"
+                                     Progress="{Binding ImportProgress}"/>
+                        <FlexLayout JustifyContent="SpaceBetween"
+                                    Margin="0,4,0,0">
+                            <Label Style="{StaticResource ExpenseCardProgressValue}"
+                                   Text="{Binding CurrentImportIndex}"/>
+                            <Label Style="{StaticResource ExpenseCardProgressValue}"
+                                   Text="{Binding TotalImportIndex}" />
+                        </FlexLayout>
+                    </StackLayout>
+
                     <Button Margin="0,16,0,0"
                             Text="{x:Static resx:AppResources.ImportExport_ChooseFile}"
                             Clicked="ImportButton_OnClicked"/>

--- a/src/Profitocracy.Mobile/Views/Settings/Pages/ImportExportSettingsPage.xaml
+++ b/src/Profitocracy.Mobile/Views/Settings/Pages/ImportExportSettingsPage.xaml
@@ -5,20 +5,45 @@
              xmlns:abstractions="clr-namespace:Profitocracy.Mobile.Abstractions"
              xmlns:resx="clr-namespace:Profitocracy.Mobile.Resources.Strings"
              xmlns:controls="clr-namespace:Profitocracy.Mobile.Views.Shared.Controls"
+             xmlns:viewmodel="clr-namespace:Profitocracy.Mobile.ViewModels.Settings"
              x:Class="Profitocracy.Mobile.Views.Settings.Pages.ImportExportSettingsPage"
+             x:DataType="viewmodel:ImportExportSettingsPageViewModel"
              BackgroundColor="{AppThemeBinding Light={StaticResource LightBackground}, Dark={StaticResource DarkBackground}}"
              Title="{x:Static resx:AppResources.Pages_ImportExport}">
-    <ScrollView>
+    <ScrollView Padding="16,8,16,16">
         <StackLayout>
             <controls:ContentSectionView Title="{x:Static resx:AppResources.ImportExport_Import}">
                 <StackLayout>
                     <Button Margin="0,16,0,0"
-                            Text="Pick a file"/>
+                            Text="{x:Static resx:AppResources.ImportExport_ChooseFile}"
+                            Clicked="ImportButton_OnClicked"/>
                 </StackLayout>
             </controls:ContentSectionView>
             <controls:ContentSectionView Title="{x:Static resx:AppResources.ImportExport_Export}">
                 <StackLayout>
-                    
+                    <StackLayout>
+                        <FlexLayout JustifyContent="SpaceBetween"
+                                    Margin="0,16,0,0">
+                            <Label Text="{x:Static resx:AppResources.ImportExport_ExportProfiles}"
+                                   VerticalTextAlignment="Center"/>
+                            <Switch IsToggled="{Binding IsExportingProfiles, Mode=TwoWay}"/>
+                        </FlexLayout>
+                        <FlexLayout JustifyContent="SpaceBetween"
+                                    Margin="0,16,0,0">
+                            <Label Text="{x:Static resx:AppResources.ImportExport_ExportCategories}"
+                                   VerticalTextAlignment="Center"/>
+                            <Switch IsToggled="{Binding IsExportingCategories, Mode=TwoWay}"/>
+                        </FlexLayout>
+                        <FlexLayout JustifyContent="SpaceBetween"
+                                    Margin="0,16,0,0">
+                            <Label Text="{x:Static resx:AppResources.ImportExport_ExportTransactions}"
+                                   VerticalTextAlignment="Center"/>
+                            <Switch IsToggled="{Binding IsExportingTransactions, Mode=TwoWay}"/>
+                        </FlexLayout>
+                    </StackLayout>
+                    <Button Margin="0,16,0,0"
+                            Text="{x:Static resx:AppResources.ImportExport_ExportFile}"
+                            Clicked="ExportButton_OnClicked"/>
                 </StackLayout>
             </controls:ContentSectionView>
         </StackLayout>

--- a/src/Profitocracy.Mobile/Views/Settings/Pages/ImportExportSettingsPage.xaml.cs
+++ b/src/Profitocracy.Mobile/Views/Settings/Pages/ImportExportSettingsPage.xaml.cs
@@ -9,6 +9,12 @@ public partial class ImportExportSettingsPage
     public ImportExportSettingsPage(ImportExportSettingsPageViewModel viewModel)
     {
         InitializeComponent();
-        _viewModel = viewModel;
+        BindingContext = _viewModel = viewModel;
     }
+
+    private void ImportButton_OnClicked(object? sender, EventArgs e)
+        => ProcessAction(_viewModel.ImportAsync);
+
+    private void ExportButton_OnClicked(object? sender, EventArgs e)
+        => ProcessAction(_viewModel.ExportAsync);
 }

--- a/src/Profitocracy.Mobile/Views/Settings/Pages/ImportExportSettingsPage.xaml.cs
+++ b/src/Profitocracy.Mobile/Views/Settings/Pages/ImportExportSettingsPage.xaml.cs
@@ -1,3 +1,4 @@
+using Profitocracy.Mobile.Resources.Strings;
 using Profitocracy.Mobile.ViewModels.Settings;
 
 namespace Profitocracy.Mobile.Views.Settings.Pages;
@@ -13,8 +14,22 @@ public partial class ImportExportSettingsPage
     }
 
     private void ImportButton_OnClicked(object? sender, EventArgs e)
-        => ProcessAction(_viewModel.ImportAsync);
+        => ProcessAction(async () =>
+        {
+            await _viewModel.ImportAsync();
+            await DisplayAlert(
+                AppResources.ImportExport_SuccessImportAlert_Title,
+                AppResources.ImportExport_SuccessImportAlert_Description,
+                AppResources.ImportExport_SuccessImportAlert_Ok);
+        });
 
     private void ExportButton_OnClicked(object? sender, EventArgs e)
-        => ProcessAction(_viewModel.ExportAsync);
+        => ProcessAction(async () =>
+        {
+            await _viewModel.ExportAsync();
+            await DisplayAlert(
+                AppResources.ImportExport_SuccessExportAlert_Title,
+                AppResources.ImportExport_SuccessExportAlert_Description,
+                AppResources.ImportExport_SuccessExportAlert_Ok);
+        });
 }

--- a/src/Profitocracy.Mobile/Views/Settings/Pages/ImportExportSettingsPage.xaml.cs
+++ b/src/Profitocracy.Mobile/Views/Settings/Pages/ImportExportSettingsPage.xaml.cs
@@ -1,0 +1,14 @@
+using Profitocracy.Mobile.ViewModels.Settings;
+
+namespace Profitocracy.Mobile.Views.Settings.Pages;
+
+public partial class ImportExportSettingsPage
+{
+    private readonly ImportExportSettingsPageViewModel _viewModel;
+
+    public ImportExportSettingsPage(ImportExportSettingsPageViewModel viewModel)
+    {
+        InitializeComponent();
+        _viewModel = viewModel;
+    }
+}

--- a/src/Profitocracy.Mobile/Views/Settings/Pages/SettingsPage.xaml
+++ b/src/Profitocracy.Mobile/Views/Settings/Pages/SettingsPage.xaml
@@ -22,6 +22,9 @@
             <controls:NavigationButton Title="{x:Static resx:AppResources.Settings_Categories}"
                                        Clicked="CategoriesButton_OnClicked"
                                        Margin="0,8,0,0"/>
+            <controls:NavigationButton Title="{x:Static resx:AppResources.Settings_ImportExport}"
+                                       Clicked="ImportExportButton_OnClicked"
+                                       Margin="0,8,0,0"/>
 
             <Label Text="{x:Static resx:AppResources.Settings_General}"
                    Style="{StaticResource SettingsGroupTitle}"

--- a/src/Profitocracy.Mobile/Views/Settings/Pages/SettingsPage.xaml.cs
+++ b/src/Profitocracy.Mobile/Views/Settings/Pages/SettingsPage.xaml.cs
@@ -21,6 +21,9 @@ public partial class SettingsPage : BaseContentPage
     private void CategoriesButton_OnClicked(object? sender, EventArgs e)
         => ProcessAction(NavigateToPage<ExpenseCategoriesSettingsPage>);
 
+    private void ImportExportButton_OnClicked(object? sender, EventArgs e)
+        => ProcessAction(NavigateToPage<ImportExportSettingsPage>);
+
     private void AuthenticationButton_OnClicked(object? sender, EventArgs e)
         => ProcessAction(NavigateToPage<AuthSettingsPage>);
 


### PR DESCRIPTION
Implemented both export and import features:
- New settings page for import and export;
- You can select the data to export: profiles, categories (can't be selected without profiles), transactions (can't be selected without profiles and categories). Backup provider will save an exported file into your filesystem. The file is just an XML-encoded file with a special extension `v1pfbkp` (means **"Profitocracy backup v1"**);
- Also you can import all the exported data into your device.