### PR TITLE
Specifying a transaction time. Fixes to profile editing process

### DIFF
--- a/src/Profitocracy.Mobile/Models/Transactions/TransactionModel.cs
+++ b/src/Profitocracy.Mobile/Models/Transactions/TransactionModel.cs
@@ -23,6 +23,7 @@ public class TransactionModel
     public required int Type { get; set; }
     public required int? SpendingType { get; set; }
     public required DateTime Timestamp { get; set; }
+    public string? TimestampDisplay => Timestamp.ToString("g", CultureInfo.CurrentCulture);
     public TransactionCategoryModel? Category { get; set; }
     public string? Description { get; set; }
 

--- a/src/Profitocracy.Mobile/ViewModels/Profiles/EditProfilePageViewModel.cs
+++ b/src/Profitocracy.Mobile/ViewModels/Profiles/EditProfilePageViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using System.Globalization;
 using Profitocracy.Core.Domain.Model.Profiles;
 using Profitocracy.Core.Domain.Model.Profiles.Factories;
+using Profitocracy.Core.Domain.Model.Profiles.ValueObjects;
 using Profitocracy.Core.Domain.Model.Shared.ValueObjects;
 using Profitocracy.Core.Persistence;
 using Profitocracy.Mobile.Abstractions;
@@ -18,6 +19,7 @@ public class EditProfilePageViewModel : BaseNotifyObject
     private Currency _currency;
     private bool _isCurrent;
     private bool _isNotFirstProfile = true;
+    private TimePeriod? _billingPeriod;
 
     private readonly IProfileRepository _profileRepository;
 
@@ -91,9 +93,10 @@ public class EditProfilePageViewModel : BaseNotifyObject
         Name = profile.Name;
         InitialBalance = profile.Balance.ToString(CultureInfo.CurrentCulture);
         SelectedCurrency = profile.Settings.Currency;
+        _billingPeriod = profile.BillingPeriod;
     }
 
-    public async Task CreateFirstProfile()
+    public async Task CreateProfile()
     {
         if (!NumberUtils.TryParseDecimal(_initialBalance, out var numValue))
         {
@@ -105,6 +108,11 @@ public class EditProfilePageViewModel : BaseNotifyObject
             .AddName(_name)
             .AddCurrency(_currency)
             .AddIsCurrent(_isCurrent);
+
+        if (_billingPeriod is not null)
+        {
+            profileBuilder.AddBillingPeriod(_billingPeriod.DateFrom, _billingPeriod.DateTo);
+        }
 
         if (_profileId is not null)
         {

--- a/src/Profitocracy.Mobile/ViewModels/Transactions/EditTransactionPageViewModel.cs
+++ b/src/Profitocracy.Mobile/ViewModels/Transactions/EditTransactionPageViewModel.cs
@@ -30,6 +30,7 @@ public class EditTransactionPageViewModel : BaseNotifyObject
     private Guid? _transactionId;
 
     private DateTime _timestamp = DateTime.Now;
+    private TimeSpan _time = DateTime.Now.TimeOfDay;
     private string _amount = string.Empty;
     private string _destinationAmount = string.Empty;
 
@@ -228,6 +229,12 @@ public class EditTransactionPageViewModel : BaseNotifyObject
         set => SetProperty(ref _timestamp, value);
     }
 
+    public TimeSpan Time
+    {
+        get => _time;
+        set => SetProperty(ref _time, value);
+    }
+
     public string Description
     {
         get => _description ?? string.Empty;
@@ -311,7 +318,7 @@ public class EditTransactionPageViewModel : BaseNotifyObject
 
     private async Task CreateTransaction()
     {
-        var transaction = await BuildTransaction(null);
+        var transaction = await BuildTransaction(transactionId: null);
         await _transactionRepository.Create(transaction);
     }
 
@@ -357,13 +364,15 @@ public class EditTransactionPageViewModel : BaseNotifyObject
             return BuildMultiCurrencyTransaction(transactionId, amount, currentProfile, category);
         }
 
+        var transactionTimestamp = _timestamp.Date.Add(_time);
+
         return TransactionFactory.CreateTransaction(
             id: transactionId,
             amount,
             currentProfile.Id,
             (TransactionType)_transactionType,
             _spendingType is null or -1 ? null : (SpendingType)_spendingType,
-            _timestamp,
+            transactionTimestamp,
             _description,
             geoTag: null,
             category);

--- a/src/Profitocracy.Mobile/Views/Settings/Pages/EditProfilePage.xaml.cs
+++ b/src/Profitocracy.Mobile/Views/Settings/Pages/EditProfilePage.xaml.cs
@@ -25,7 +25,7 @@ public partial class EditProfilePage : BaseContentPage
     {
         ProcessAction(async () =>
         {
-            await _viewModel.CreateFirstProfile();
+            await _viewModel.CreateProfile();
             await Navigation.PopModalAsync();
         });
     }

--- a/src/Profitocracy.Mobile/Views/Transactions/Controls/TransactionView.xaml
+++ b/src/Profitocracy.Mobile/Views/Transactions/Controls/TransactionView.xaml
@@ -68,7 +68,7 @@
                            Text="{Binding AdditionalDisplayAmount}" />
                     <Label Style="{StaticResource TransactionCardDate}"
                            Margin="0,4,0,0"
-                           Text="{Binding Timestamp, StringFormat='{0:dd/MM/yyyy hh:mm}'}"/>
+                           Text="{Binding TimestampDisplay}"/>
                 </StackLayout>
             </FlexLayout>
         </StackLayout>

--- a/src/Profitocracy.Mobile/Views/Transactions/Pages/EditTransactionPage.xaml
+++ b/src/Profitocracy.Mobile/Views/Transactions/Pages/EditTransactionPage.xaml
@@ -16,11 +16,11 @@
                               HideSoftInputOnTapped="True">
     <Grid VerticalOptions="Fill"
           RowDefinitions="auto,auto,*,auto">
-        
-        <controls:ModalHeaderView Grid.Row="0" 
-                                  Title="{x:Static resx:AppResources.Pages_NewTransaction}" 
+
+        <controls:ModalHeaderView Grid.Row="0"
+                                  Title="{x:Static resx:AppResources.Pages_NewTransaction}"
                                   CloseClicked="CloseButton_OnClicked"/>
-        
+
         <Grid Grid.Row="1"
               Margin="0,32,0,0"
               ColumnDefinitions="*,16,*">
@@ -50,7 +50,7 @@
                     </Style>
                 </Button.Style>
             </Button>
-            <Button Grid.Column="2" 
+            <Button Grid.Column="2"
                     Text="{x:Static resx:AppResources.AddTransaction_Income}"
                     x:Name="IncomeButton"
                     Clicked="IncomeButton_OnClicked">
@@ -89,7 +89,7 @@
                                 <Label Text="{x:Static resx:AppResources.AddTransaction_WithdrawSavedFunds}"
                                        Style="{StaticResource ExpenseCardSubtitle}"
                                        VerticalTextAlignment="Start"/>
-                                <Switch IsToggled="{Binding IsMultiCurrency, Mode=TwoWay}"/>    
+                                <Switch IsToggled="{Binding IsMultiCurrency, Mode=TwoWay}"/>
                             </FlexLayout>
                             <StackLayout Margin="0,16,0,0">
                                 <Label Text="{x:Static resx:AppResources.AddTransaction_Amount}"/>
@@ -106,25 +106,25 @@
                                         <ColumnDefinition Width="8"/>
                                         <ColumnDefinition Width="3*" />
                                     </Grid.ColumnDefinitions>
-                                    
+
                                     <Picker Grid.Column="0"
                                             x:Name="IncomeCurrencyPicker"
                                             SelectedItem="{Binding SelectedCurrency}"
                                             ItemDisplayBinding="{Binding Code}"/>
-                                    <Entry Grid.Column="2" 
+                                    <Entry Grid.Column="2"
                                            Keyboard="Numeric"
                                            Text="{Binding DestinationAmount, Mode=TwoWay}"/>
                                 </Grid>
                             </StackLayout>
                         </StackLayout>
                     </Border>
-            
+
                     <StackLayout Margin="0,16,0,0">
                         <Label Text="{x:Static resx:AppResources.AddTransaction_Description}"/>
                         <Entry Margin="0,4,0,0"
                                Text="{Binding Description, Mode=TwoWay}"/>
                     </StackLayout>
-            
+
                     <StackLayout Margin="0,16,0,0">
                         <Label Text="{x:Static resx:AppResources.AddTransaction_Date}"/>
                         <DatePicker Margin="0,4,0,0"
@@ -209,7 +209,7 @@
                             </Button.Style>
                         </Button>
                     </Grid>
-                
+
                     <Border Style="{StaticResource TransactionAddAmountBorder}"
                             Padding="16"
                             Margin="0,16,0,0">
@@ -218,7 +218,7 @@
                                 <Label Text="{x:Static resx:AppResources.AddTransaction_MultiCurrencyTransaction}"
                                        Style="{StaticResource ExpenseCardSubtitle}"
                                        VerticalTextAlignment="Start"/>
-                                <Switch IsToggled="{Binding IsMultiCurrency, Mode=TwoWay}"/>    
+                                <Switch IsToggled="{Binding IsMultiCurrency, Mode=TwoWay}"/>
                             </FlexLayout>
                             <StackLayout Margin="0,16,0,0"
                                          IsVisible="{Binding IsMultiCurrency}">
@@ -229,12 +229,12 @@
                                         <ColumnDefinition Width="8"/>
                                         <ColumnDefinition Width="3*" />
                                     </Grid.ColumnDefinitions>
-                                    
+
                                     <Picker Grid.Column="0"
                                             x:Name="ExpenseCurrencyPicker"
                                             SelectedItem="{Binding SelectedCurrency}"
                                             ItemDisplayBinding="{Binding Code}"/>
-                                    <Entry Grid.Column="2" 
+                                    <Entry Grid.Column="2"
                                            Keyboard="Numeric"
                                            Text="{Binding DestinationAmount, Mode=TwoWay}"/>
                                 </Grid>
@@ -247,7 +247,7 @@
                             </StackLayout>
                         </StackLayout>
                     </Border>
-                    
+
                     <StackLayout Margin="0,16,0,0">
                         <Label Text="{x:Static resx:AppResources.AddTransaction_Category}"/>
                         <Picker Margin="0,4,0,0"
@@ -255,17 +255,22 @@
                                 SelectedItem="{Binding Category}"
                                 ItemDisplayBinding="{Binding Name}" />
                     </StackLayout>
-                
+
                     <StackLayout Margin="0,16,0,0">
                         <Label Text="{x:Static resx:AppResources.AddTransaction_Description}"/>
                         <Entry Margin="0,4,0,0"
                                Text="{Binding Description, Mode=TwoWay}"/>
                     </StackLayout>
-                
+
                     <StackLayout Margin="0,16,0,0">
                         <Label Text="{x:Static resx:AppResources.AddTransaction_Date}"/>
-                        <DatePicker Margin="0,4,0,0"
-                                    Date="{Binding Timestamp, Mode=TwoWay}"/>
+                        <Grid ColumnDefinitions="*,8,*"
+                              Margin="0,4,0,0">
+                            <DatePicker Grid.Column="0"
+                                        Date="{Binding Timestamp, Mode=TwoWay}"/>
+                            <TimePicker Grid.Column="2"
+                                        Time="{Binding Time, Mode=TwoWay}"/>
+                        </Grid>
                     </StackLayout>
                 </StackLayout>
             </StackLayout>


### PR DESCRIPTION
- Added specifying the time of a transaction.
- Fixed profile editing. Billing period of a profile is now correctly defined while profile saving.